### PR TITLE
Fixes #12 - tasks disappear when rotating device

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/ui/fragments/TaskRecyclerViewFragment.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/fragments/TaskRecyclerViewFragment.java
@@ -63,6 +63,7 @@ public class TaskRecyclerViewFragment extends Fragment implements View.OnClickLi
 
     public static TaskRecyclerViewFragment newInstance(HabitItemRecyclerViewAdapter adapter, String classType) {
         TaskRecyclerViewFragment fragment = new TaskRecyclerViewFragment();
+        fragment.setRetainInstance(true);
 
         fragment.SetInnerAdapter(adapter, classType);
 


### PR DESCRIPTION
Fixes #12.

According to [Android documentation](http://developer.android.com/guide/topics/resources/runtime-changes.html#RetainingAnObject)

"In such a situation, you can alleviate the burden of reinitializing your activity by retaining a Fragment when your activity is restarted due to a configuration change. This fragment can contain references to stateful objects that you want to retain.

When the Android system shuts down your activity due to a configuration change(**DEVICE ROTATION**), the fragments of your activity that you have marked to retain are not destroyed."

With this in mind, I just preserved the state of TaskRecyclerViewFragment.

<img width="764" alt="screenshot 2015-11-08 18 02 33" src="https://cloud.githubusercontent.com/assets/868917/11022670/026f402a-8643-11e5-924f-7cbc1396429f.png">
<img width="753" alt="screenshot 2015-11-08 18 02 47" src="https://cloud.githubusercontent.com/assets/868917/11022669/026f44e4-8643-11e5-8a0e-82fb818e45c8.png">

Everything is working on my side as you can see above. Let me know if this bug persists.
