### PR TITLE
[#76] Reduce About loading time by loading one fragment at a time

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/AboutActivity.java
+++ b/Habitica/src/com/habitrpg/android/habitica/AboutActivity.java
@@ -52,6 +52,7 @@ public class AboutActivity extends AppCompatActivity {
         final PagerAdapter adapter = new PagerAdapter(getSupportFragmentManager(), 3);
         pager.setAdapter(adapter);
         pager.addOnPageChangeListener(new TabLayout.TabLayoutOnPageChangeListener(tabLayout));
+        pager.setOffscreenPageLimit(1);
 
         tabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
             @Override


### PR DESCRIPTION
Fixes #76.

This should be re-think if we add more tabs. The problem is related to the libraries we are using in the About Screen: Paperboy and LibsBuilder. Probably in the future we can add that for different screens.

Probably, someone can see it a little bit slow if the Android phone has < 1gb RAM and a processor not so good too.
