### PR TITLE
Fix OutOfBounds in Array on CheckListAdapter. Closes #221

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/ui/adapter/CheckListAdapter.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/adapter/CheckListAdapter.java
@@ -63,7 +63,7 @@ public class CheckListAdapter extends RecyclerView.Adapter<CheckListAdapter.Item
 
     @Override
     public void onItemDismiss(int position) {
-        if(position != -1 && position > 0 && !mItems.isEmpty()){
+        if(position >= 0 && position < mItems.size()){
             mItems.remove(position);
             notifyItemRemoved(position);
         }


### PR DESCRIPTION
Some possible reasons:
- https://code.google.com/p/android/issues/detail?can=1&q=77846&colspec=ID%20Type%20Status%20Owner%20Summary%20Stars&id=77846
- https://code.google.com/p/android/issues/detail?id=77232
- Concurrent change on this state. 

The solution I did is just a validation to prevent the crash.
