### PR TITLE
remove calls to crashlytics on retrofit errors.

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/HabitRPGUserCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/HabitRPGUserCallback.java
@@ -27,8 +27,6 @@ public class HabitRPGUserCallback implements Callback<HabitRPGUser> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.getInstance().core.logException(error);
-
         mCallback.onUserFail();
     }
 

--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/SkillCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/SkillCallback.java
@@ -32,7 +32,6 @@ public class SkillCallback implements Callback<HabitRPGUser> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.logException(error);
         callback.onUserFail();
     }
 }

--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskCreationCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskCreationCallback.java
@@ -23,8 +23,6 @@ public class TaskCreationCallback implements Callback<Task> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.logException(error);
-
         Log.w("HabitCreation", "Error " + error.getMessage());
     }
 }

--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskDeletionCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskDeletionCallback.java
@@ -28,8 +28,6 @@ public class TaskDeletionCallback implements Callback<Void> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.logException(error);
-
         callback.onTaskDeletionFail();
         Log.w("HabitDeletion", "Error " + error.getMessage());
     }

--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskScoringCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskScoringCallback.java
@@ -37,8 +37,6 @@ public class TaskScoringCallback implements Callback<TaskDirectionData> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.logException(error);
-
         this.mCallback.onTaskScoringFailed();
         Log.w("TaskScoring", "Task scoring failed " + error.getMessage());
     }

--- a/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskUpdateCallback.java
+++ b/Habitica/src/com/habitrpg/android/habitica/callbacks/TaskUpdateCallback.java
@@ -25,8 +25,6 @@ public class TaskUpdateCallback implements Callback<Task> {
 
     @Override
     public void failure(RetrofitError error) {
-        Crashlytics.logException(error);
-
         Log.w("HabitUpdate", "Error " + error.getMessage());
     }
 


### PR DESCRIPTION
This is most likely the reason so many non-fatal retrofit errors end up in crashlytics. According to the docs, non-fatal exceptions are only logged when excplicitly sent. So I removed all the logException calls ;)
