### PR TITLE
Single click Tasks FAB

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.java
@@ -229,4 +229,8 @@ public class TaskRecyclerViewFragment extends BaseFragment implements View.OnCli
     public String getDisplayedClassName() {
         return this.classType + super.getDisplayedClassName();
     }
+
+    String getClassName() {
+        return this.classType;
+    }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -153,12 +153,21 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
         todo_fab.setOnClickListener(v1 -> openNewTaskActivity("todo"));
         FloatingActionButton reward_fab = (FloatingActionButton) floatingMenu.findViewById(R.id.fab_new_reward);
         reward_fab.setOnClickListener(v1 -> openNewTaskActivity("reward"));
+        floatingMenu.setOnMenuButtonLongClickListener(this::onFloatingMenuLongClicked);
 
         this.activity.unlockDrawer(GravityCompat.END);
 
         loadTaskLists();
 
         return v;
+    }
+
+    private boolean onFloatingMenuLongClicked(View view) {
+        int currentType = viewPager.getCurrentItem();
+        TaskRecyclerViewFragment currentFragment = ViewFragmentsDictionary.get(currentType);
+        String className = currentFragment.getClassName();
+        openNewTaskActivity(className);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
My Habitica User-ID: fb933ec8-daa3-4a33-9a3c-6abf20a291ae

Fixes #410

Currently the tasks page FAB presents you with a menu, which is best suited for a page that displays multiple types of data. However, this means that whichever type of data you are viewing (Habits, Todos etc), you have to press the FAB and then select the right option in the list of small FABs.

This change instead means you simply press the FAB and it goes to the add page for the type of data you are currently viewing. I.e. when on the Habits tab pressing the FAB goes to the Add Habit page.
- The app wouldn't build without updating the Material Dialogs dependency, the build error was due to the previous version not being found. This was the same in my other active Pull Request.
