### PR TITLE
Recieve the boot command so that we can reschedule alarms.

### DIFF
--- a/Habitica/AndroidManifest.xml
+++ b/Habitica/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- For rescheduling notifications -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.android.vending.BILLING" />
 
     <application
@@ -116,6 +118,11 @@
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:label="@string/app_name" />
         <receiver  android:process=":remote" android:name=".NotificationPublisher" />
+        <receiver android:name=".BootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:name="android.support.v4.content.FileProvider"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/BootReceiver.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/BootReceiver.java
@@ -1,0 +1,22 @@
+package com.habitrpg.android.habitica;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Boot receiver so that we can restore alarms when the phone boots.
+ *
+ * Keep in mind that the BootReceiver does not work for applications
+ * installed on external storage
+ */
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        scheduleReminder(context);
+    }
+
+    private void scheduleReminder(Context context) {
+        NotificationPublisher.scheduleNotifications(context);
+    }
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
@@ -1,8 +1,5 @@
 package com.habitrpg.android.habitica.ui.activities;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -24,7 +21,6 @@ import android.support.v4.content.FileProvider;
 import android.support.v4.view.GravityCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
-import android.util.AttributeSet;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -37,11 +33,9 @@ import com.amplitude.api.Amplitude;
 import com.habitrpg.android.habitica.APIHelper;
 import com.habitrpg.android.habitica.HabiticaApplication;
 import com.habitrpg.android.habitica.HostConfig;
-import com.habitrpg.android.habitica.NotificationPublisher;
 import com.habitrpg.android.habitica.R;
 import com.habitrpg.android.habitica.callbacks.HabitRPGUserCallback;
 import com.habitrpg.android.habitica.callbacks.ItemsCallback;
-import com.habitrpg.android.habitica.callbacks.MergeUserCallback;
 import com.habitrpg.android.habitica.callbacks.TaskScoringCallback;
 import com.habitrpg.android.habitica.callbacks.UnlockCallback;
 import com.habitrpg.android.habitica.databinding.ValueBarBinding;
@@ -72,7 +66,6 @@ import com.habitrpg.android.habitica.ui.fragments.GemsPurchaseFragment;
 import com.habitrpg.android.habitica.ui.helpers.DataBindingUtils;
 import com.habitrpg.android.habitica.userpicture.BitmapUtils;
 import com.habitrpg.android.habitica.userpicture.UserPicture;
-import com.habitrpg.android.habitica.userpicture.UserPictureRunnable;
 import com.magicmicky.habitrpgwrapper.lib.models.ContentResult;
 import com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser;
 import com.magicmicky.habitrpgwrapper.lib.models.SuppressedModals;
@@ -118,8 +111,6 @@ import org.solovyev.android.checkout.ActivityCheckout;
 import org.solovyev.android.checkout.Checkout;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -188,9 +179,6 @@ public class MainActivity extends BaseActivity implements HabitRPGUserCallback.O
         this.hostConfig = PrefsActivity.fromContext(this);
         if (!HabiticaApplication.checkUserAuthentication(this, hostConfig))
             return;
-
-        //Check if reminder alarm is set
-        scheduleReminder(this);
 
         HabiticaApplication.ApiHelper = this.mAPIHelper = new APIHelper(hostConfig);
 
@@ -1099,35 +1087,6 @@ public class MainActivity extends BaseActivity implements HabitRPGUserCallback.O
 
     public FrameLayout getFloatingMenuWrapper() {
         return floatingMenuWrapper;
-    }
-
-    private void scheduleReminder(Context context) {
-
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-
-        if (prefs.getBoolean("use_reminder", false)) {
-
-            String timeval = prefs.getString("reminder_time", "19:00");
-
-            String[] pieces = timeval.split(":");
-            int hour = Integer.parseInt(pieces[0]);
-            int minute = Integer.parseInt(pieces[1]);
-            Calendar cal = Calendar.getInstance();
-            cal.set(Calendar.HOUR_OF_DAY, hour);
-            cal.set(Calendar.MINUTE, minute);
-            long trigger_time = cal.getTimeInMillis();
-
-            Intent notificationIntent = new Intent(context, NotificationPublisher.class);
-            notificationIntent.putExtra(NotificationPublisher.NOTIFICATION_ID, 1);
-            notificationIntent.putExtra(NotificationPublisher.CHECK_DAILIES, false);
-
-            if (PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_NO_CREATE) == null) {
-                PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-
-                AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-                alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, trigger_time, AlarmManager.INTERVAL_DAY, pendingIntent);
-            }
-        }
     }
 
     @Subscribe


### PR DESCRIPTION
my Habitica User-ID: f52b69aa-b48c-4db8-b8ca-7d9c43d84a42

Hey there, love the app. So, I have created a few apps that show a daily reminder, and my wife noticed that she was not getting her daily reminders after rebooting her phone. Turns out it is the same issue I have run into many times before, including in [this app](https://github.com/Jawnnypoo/open-meh)

The problem is that all alarms scheduled with AlarmManager get canceled/destroyed when the user reboots their device. Therefore, you must register to receive the on boot event on the device so that you can reschedule the notification. 

This will fix the issue for those individuals who may have reset their devices and not yet opened up the app and given it a chance to reschedule notification delivery. Therefore, we no longer need that check in MainActivity. 

I also went about centralizing the code for scheduling the notification since it was duplicated both in the preference fragment as well as in MainActivity. This way if it ever changes, it will just need to be changed in one place. 

One caveat to all this is that your receiver only gets the boot event if the app is installed on internal storage, as external storage and apps get mounted after the boot command is issued. So, users who have the app installed on external storage will have the issue with their notifications not getting rescheduled. I would suggest restricting the app to only be installed on internal storage. Let me know, and I can add that change to this PR.