### PR TITLE
Fix daily reminders (for myself)

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.java
@@ -157,23 +157,24 @@ public class PreferencesFragment extends BasePreferencesFragment implements
         cal.set(Calendar.MINUTE, minute);
         long trigger_time = cal.getTimeInMillis();
 
+        PendingIntent displayIntent = getNotificationDisplayIntent();
+
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, trigger_time, AlarmManager.INTERVAL_DAY, displayIntent);
+    }
+
+    private void removeNotifications() {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        PendingIntent displayIntent = getNotificationDisplayIntent();
+        alarmManager.cancel(displayIntent);
+    }
+
+    private PendingIntent getNotificationDisplayIntent() {
         Intent notificationIntent = new Intent(context, NotificationPublisher.class);
         notificationIntent.putExtra(NotificationPublisher.NOTIFICATION_ID, 1);
         notificationIntent.putExtra(NotificationPublisher.CHECK_DAILIES, false);
 
-        if (PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_NO_CREATE) == null) {
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-
-            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-            alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, trigger_time, AlarmManager.INTERVAL_DAY, pendingIntent);
-        }
-    }
-
-    private void removeNotifications() {
-        Intent notificationIntent = new Intent(context, NotificationPublisher.class);
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        PendingIntent displayIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, 0);
-        alarmManager.cancel(displayIntent);
+        return PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
     }
 
     @Override

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.java
@@ -155,6 +155,14 @@ public class PreferencesFragment extends BasePreferencesFragment implements
         Calendar cal = Calendar.getInstance();
         cal.set(Calendar.HOUR_OF_DAY, hour);
         cal.set(Calendar.MINUTE, minute);
+
+        // If the calendar represents a time in the past today, set it to first appear at that
+        // time tomorrow instead.
+        Calendar now = Calendar.getInstance();
+        if(cal.compareTo(now) < 0) {
+            cal.roll(Calendar.DATE, true);
+        }
+
         long trigger_time = cal.getTimeInMillis();
 
         PendingIntent displayIntent = getNotificationDisplayIntent();


### PR DESCRIPTION
My Habitica User-ID: not sure why this is needed but I can provide it if required!

I wasn't getting any reminder notifications (Nexus 5, stock ROM), in spite of having the checkbox ticked and a time set. A little debugging showed that `(PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_NO_CREATE) == null)` was returning `false`, possibly because the intent didn't have the same `putExtra`s so wasn't considered equal to the existing intent.

This fixes that, and relies on `PendingIntent.FLAG_CANCEL_CURRENT` to cancel any existing notifications.

I hope that makes sense - let me know if this doesn't look right.