### PR TITLE
Quicker adding of reminders

### DIFF
--- a/Habitica/res/layout/activity_task_form.xml
+++ b/Habitica/res/layout/activity_task_form.xml
@@ -318,7 +318,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="20dp"
             android:orientation="vertical">
 
             <TextView
@@ -333,28 +333,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <LinearLayout
+            <EditText
+                android:id="@+id/new_reminder_edittext"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal">
-
-                <EditText
-                    android:id="@+id/new_reminder_edittext"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:hint="@string/start_date"
-                    android:textColor="@android:color/black"
-                    android:focusable="false" />
-
-                <Button
-                    android:id="@+id/add_reminder_button"
-                    style="?android:attr/buttonStyleSmall"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/add_checklist_item" />
-            </LinearLayout>
+                android:layout_gravity="center_horizontal"
+                android:hint="@string/start_date"
+                android:textColor="@android:color/black"
+                android:focusable="false" />
 
         </LinearLayout>
 
@@ -362,6 +348,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:layout_marginTop="20dp"
         android:id="@+id/task_tags_wrapper">
 
         <TextView

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/RemindersManager.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/RemindersManager.java
@@ -5,6 +5,7 @@ import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.support.v7.preference.PreferenceManager;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -26,7 +27,7 @@ import java.util.UUID;
  */
 public class RemindersManager {
 
-    DateFormat dateFormater;
+    private DateFormat dateFormater;
 
     public RemindersManager(String taskType) {
         if (taskType.equals("todo")) {
@@ -56,7 +57,8 @@ public class RemindersManager {
         return dateFormater.format(time);
     }
 
-    public void createDialogeForEditText(EditText editText, String taskType, Context context, RemindersItem reminder) {
+    public void createReminderTimeDialog(@Nullable ReminderTimeSelectedCallback callback, String taskType,
+                                         Context context, @Nullable RemindersItem reminder) {
         Calendar currentTime = Calendar.getInstance();
         int hour = currentTime.get(Calendar.HOUR_OF_DAY);
         int minute = currentTime.get(Calendar.MINUTE);
@@ -92,11 +94,7 @@ public class RemindersManager {
                 Calendar calendar = Calendar.getInstance();
                 calendar.set(year, month, day, hour1, minute1, 0);
 
-                if (reminder != null) {
-                    reminder.setTime(calendar.getTime());
-                }
-
-                editText.setText(dateFormater.format(calendar.getTime()));
+                onReminderTimeSelected(callback, reminder, calendar);
                 dialog.hide();
             });
             dialog.show();
@@ -106,15 +104,26 @@ public class RemindersManager {
                 Calendar calendar = Calendar.getInstance();
                 calendar.set(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE), selectedHour, selectedMinute, 0);
 
-                if (reminder != null) {
-                    reminder.setTime(calendar.getTime());
-                }
-
-                editText.setText(dateFormater.format(calendar.getTime()));
+                onReminderTimeSelected(callback, reminder, calendar);
             }, hour, minute, true);
             timePickerDialog.setTitle("Select Time");
             timePickerDialog.show();
         }
     }
 
+    private void onReminderTimeSelected(ReminderTimeSelectedCallback callback, RemindersItem reminder, Calendar calendar) {
+        RemindersItem remindersItem = reminder;
+        if (remindersItem == null) {
+            remindersItem = createReminderFromDateString(dateFormater.format(calendar.getTime()));
+        } else {
+            remindersItem.setTime(calendar.getTime());
+        }
+        if (callback != null) {
+            callback.onReminderTimeSelected(remindersItem);
+        }
+    }
+
+    public interface ReminderTimeSelectedCallback {
+        void onReminderTimeSelected(RemindersItem remindersItem);
+    }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.java
@@ -160,9 +160,6 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
     @BindView(R.id.reminders_recycler_view)
     RecyclerView remindersRecyclerView;
 
-    @BindView(R.id.add_reminder_button)
-    Button addReminderButton;
-
     @BindView(R.id.emoji_toggle_btn0)
     ImageButton emojiToggle0;
 
@@ -488,22 +485,13 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
         mItemTouchHelper.attachToRecyclerView(remindersRecyclerView);
     }
 
-    @OnClick(R.id.add_reminder_button)
-    public void addReminder() {
-        if (newRemindersEditText.getText().length() > 0) {
-            RemindersItem item = remindersManager.createReminderFromDateString(newRemindersEditText.getText().toString());
-            if (item == null) {
-                return;
-            }
-            item.setType(taskType);
-            remindersAdapter.addItem(item);
-            newRemindersEditText.setText("");
-        }
+    private void addNewReminder(RemindersItem remindersItem) {
+        remindersAdapter.addItem(remindersItem);
     }
 
     @OnClick(R.id.new_reminder_edittext)
-    public void changeNewReminderTime() {
-        remindersManager.createDialogeForEditText(newRemindersEditText, taskType, this, null);
+    public void selectNewReminderTime() {
+        remindersManager.createReminderTimeDialog(this::addNewReminder, taskType, this, null);
     }
 
     private void createTagsCheckBoxes() {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/tasks/RemindersAdapter.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/tasks/RemindersAdapter.java
@@ -6,23 +6,15 @@ import com.habitrpg.android.habitica.ui.helpers.ItemTouchHelperAdapter;
 import com.habitrpg.android.habitica.ui.helpers.ItemTouchHelperViewHolder;
 import com.magicmicky.habitrpgwrapper.lib.models.tasks.RemindersItem;
 
-import android.app.Dialog;
-import android.app.TimePickerDialog;
 import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.DatePicker;
 import android.widget.EditText;
-import android.widget.TimePicker;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -115,7 +107,7 @@ public class RemindersAdapter extends RecyclerView.Adapter<RemindersAdapter.Item
                     taskType = reminder.getTask().getType();
                 }
 
-                remindersManager.createDialogeForEditText(reminderItemTextView, taskType, v.getContext(), reminder);
+                remindersManager.createReminderTimeDialog(null, taskType, v.getContext(), reminder);
             });
         }
 


### PR DESCRIPTION
my Habitica User-ID: fb933ec8-daa3-4a33-9a3c-6abf20a291ae

Fixes #583. Add reminders more quickly and easily. The confirm/ok button on the date/time dialog adds the reminder, rather than needing the extra Add button step. Removed the add button as after this change it doesn't do anything.