### PR TITLE
Remove debuggable setup from gralde

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -168,7 +168,6 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-            debuggable true
             // Disable fabric build ID generation for debug builds
             ext.enableCrashlytics = false
             resValue "string", "content_provider", "com.habitrpg.android.habitica.debug.fileprovider"
@@ -176,7 +175,6 @@ android {
         }
         release {
             signingConfig signingConfigs.release
-            debuggable false
             multiDexEnabled true
 
             resValue "string", "content_provider", "com.habitrpg.android.habitica.fileprovider"


### PR DESCRIPTION
my Habitica User-ID: 6a5dcf62-46d7-41f6-b4a5-19b1bc8a3784

The `debug` builds are debuggeable by default and `release` are not.