### PR TITLE
Filter drawer fix

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -107,16 +107,6 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        if (user != null) {
-            tags = user.getTags();
-            fillTagFilterDrawer(tags);
-        }
-    }
-
-    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
@@ -149,6 +139,16 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
         loadTaskLists();
 
         return v;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (user != null) {
+            tags = user.getTags();
+            fillTagFilterDrawer(tags);
+        }
     }
 
     @Override

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -16,7 +16,6 @@ import com.habitrpg.android.habitica.events.commands.EditTagCommand;
 import com.habitrpg.android.habitica.events.commands.FilterTasksByTagsCommand;
 import com.habitrpg.android.habitica.events.commands.RefreshUserCommand;
 import com.habitrpg.android.habitica.events.commands.UpdateTagCommand;
-import com.habitrpg.android.habitica.helpers.SoundManager;
 import com.habitrpg.android.habitica.helpers.TagsHelper;
 import com.habitrpg.android.habitica.ui.activities.MainActivity;
 import com.habitrpg.android.habitica.ui.activities.TaskFormActivity;
@@ -83,13 +82,10 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
     MenuItem refreshItem;
     FloatingActionMenu floatingMenu;
     Map<Integer, TaskRecyclerViewFragment> ViewFragmentsDictionary = new HashMap<>();
-    private ArrayList<String> tagNames; // Added this so other activities/fragments can get the String names, not IDs
-    private ArrayList<String> tagIds; // Added this so other activities/fragments can get the IDs
 
     private boolean displayingTaskForm;
     private boolean editingTags;
     private List<Tag> tags;
-    private List<Tag> tagsCopy;
     private HashMap<String, Boolean> tagFilterMap = new HashMap<>();
     private Debounce filterChangedHandler = new Debounce(1500, 1000) {
         @Override


### PR DESCRIPTION
Just delay slightly when we fill the tag filter drawer - from onCreate to onActivityCreated.

Android onCreate docs advise this:

"Note that this can be called while the fragment's activity is still in the process of being created. As such, you can not rely on things like the activity's content view hierarchy being initialized at this point. If you want to do work once the activity itself is created, see onActivityCreated(Bundle)."

https://developer.android.com/reference/android/app/Fragment.html#onCreate(android.os.Bundle)

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14

