### PR TITLE
Add stacktrace and disable predex for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ script:
     - cp habitica.properties.travis habitica.properties
     - cp habitica.resources.example habitica.resources
     - cp Habitica/google-services.json.example Habitica/google-services.json
-    - ./gradlew assembleDebug
-    - ./gradlew testDebugUnitTest --info
+    - ./gradlew assembleDebug -PdisablePreDex
+    - ./gradlew testDebugUnitTest -PdisablePreDex --stacktrace --info


### PR DESCRIPTION
my Habitica User-ID: 6a5dcf62-46d7-41f6-b4a5-19b1bc8a3784

- Its easier to debug if stacktrace is printed on ci.
- CI runs should have pre dex disabled for performance. 
