### PR TITLE
Update robolectric & re-enable alarm manager tests

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
-    testCompile "org.robolectric:robolectric:3.2-rc1"
+    testCompile "org.robolectric:robolectric:3.2"
     testCompile 'org.robolectric:shadows-multidex:3.1'
     testCompile "org.robolectric:shadows-support-v4:3.1"
     testCompile "org.mockito:mockito-core:1.10.19"

--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
-    testCompile "org.robolectric:robolectric:3.1"
+    testCompile "org.robolectric:robolectric:3.2-rc1"
     testCompile 'org.robolectric:shadows-multidex:3.1'
     testCompile "org.robolectric:shadows-support-v4:3.1"
     testCompile "org.mockito:mockito-core:1.10.19"

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/BaseAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/BaseAPITests.java
@@ -7,21 +7,11 @@ import com.habitrpg.android.habitica.HostConfig;
 import com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser;
 import com.magicmicky.habitrpgwrapper.lib.models.UserAuthResponse;
 import com.magicmicky.habitrpgwrapper.lib.models.responses.HabitResponse;
-import com.magicmicky.habitrpgwrapper.lib.models.tasks.Task;
-import com.magicmicky.habitrpgwrapper.lib.models.tasks.TaskList;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
-
-import android.os.Build;
 
 import java.security.InvalidParameterException;
-import java.util.List;
 import java.util.UUID;
 
 import rx.observers.TestSubscriber;

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/SocialAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/SocialAPITests.java
@@ -4,7 +4,6 @@ import com.habitrpg.android.habitica.BuildConfig;
 import com.magicmicky.habitrpgwrapper.lib.models.ChatMessage;
 import com.magicmicky.habitrpgwrapper.lib.models.Group;
 import com.magicmicky.habitrpgwrapper.lib.models.PostChatMessageResult;
-import com.magicmicky.habitrpgwrapper.lib.models.UserAuthResponse;
 import com.magicmicky.habitrpgwrapper.lib.models.responses.HabitResponse;
 
 import org.junit.After;
@@ -21,9 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import rx.observers.TestSubscriber;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
 @RunWith(RobolectricGradleTestRunner.class)

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/SocialAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/SocialAPITests.java
@@ -9,7 +9,6 @@ import com.magicmicky.habitrpgwrapper.lib.models.responses.HabitResponse;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -22,7 +21,7 @@ import java.util.List;
 import rx.observers.TestSubscriber;
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class SocialAPITests extends BaseAPITests {
 
     List<String> messagesIDs;

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/TagAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/TagAPITests.java
@@ -5,9 +5,10 @@ import com.magicmicky.habitrpgwrapper.lib.models.Tag;
 import com.magicmicky.habitrpgwrapper.lib.models.responses.HabitResponse;
 
 import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import android.os.Build;
@@ -17,7 +18,7 @@ import java.util.UUID;
 import rx.observers.TestSubscriber;
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class TagAPITests extends BaseAPITests {
 
     @Test

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/TaskAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/TaskAPITests.java
@@ -9,7 +9,7 @@ import com.magicmicky.habitrpgwrapper.lib.models.tasks.TaskList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import android.os.Build;
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class TaskAPITests extends BaseAPITests {
 
     private Task habit1;

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/api/UserAPITests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/api/UserAPITests.java
@@ -11,7 +11,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import android.os.Build;
@@ -24,7 +24,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class UserAPITests extends BaseAPITests {
 
     @Test

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManagerTest.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManagerTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlertDialog;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  */
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class PopupNotificationsManagerTest {
 
     public APIHelper apiHelper;

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
@@ -49,12 +49,6 @@ public class TaskAlarmManagerTest {
     }
 
     @Test
-    public void dummyTest() {
-        //temporary dummy test until the actual tests can be fixed.
-        assertTrue(true);
-    }
-/*
-    @Test
     public void testItSchedulesAlarmsForTodosWithMultipleReminders() {
         Task task = new Task();
         task.setType(Task.TYPE_TODO);
@@ -364,5 +358,5 @@ public class TaskAlarmManagerTest {
         if (expectedDay == 0) { expectedDay = 7;};
 
         Assert.assertEquals(expectedDay, newReminderTime.get(Calendar.DAY_OF_WEEK));
-    }*/
+    }
 }

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
@@ -1,14 +1,8 @@
 package com.habitrpg.android.habitica.helpers;
 
-import android.app.AlarmManager;
 import android.app.PendingIntent;
-import android.app.admin.SystemUpdatePolicy;
 import android.content.Context;
 import android.content.Intent;
-
-import android.os.Build;
-import android.test.mock.MockContext;
-import android.util.Log;
 
 import com.habitrpg.android.habitica.HabitDatabase;
 import com.habitrpg.android.habitica.receivers.TaskReceiver;
@@ -22,21 +16,16 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 /**
  * Created by keithholliday on 7/16/16.
  */

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/TaskAlarmManagerTest.java
@@ -1,9 +1,5 @@
 package com.habitrpg.android.habitica.helpers;
 
-import android.app.PendingIntent;
-import android.content.Context;
-import android.content.Intent;
-
 import com.habitrpg.android.habitica.HabitDatabase;
 import com.habitrpg.android.habitica.receivers.TaskReceiver;
 import com.magicmicky.habitrpgwrapper.lib.models.tasks.Days;
@@ -20,12 +16,14 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.UUID;
-
-import static org.junit.Assert.assertTrue;
 /**
  * Created by keithholliday on 7/16/16.
  */
@@ -308,7 +306,7 @@ public class TaskAlarmManagerTest {
         Assert.assertNotNull(alarmId);
         Assert.assertEquals(true, alarmUp);
 
-        int expectedDay = (currentDayOfTheWeek + everyXDay) % 8;
+        int expectedDay = (currentDayOfTheWeek + everyXDay) % 7;
         if (expectedDay == 0) { expectedDay = 7;};
 
         Assert.assertEquals(expectedDay, newReminderTime.get(Calendar.DAY_OF_WEEK));

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/ui/fragments/BaseFragmentTests.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/ui/fragments/BaseFragmentTests.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertNull;
 
 
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 abstract public class BaseFragmentTests<F extends Fragment> {
 
     public F fragment;

--- a/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUserTest.java
+++ b/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUserTest.java
@@ -5,7 +5,7 @@ import com.habitrpg.android.habitica.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import static org.junit.Assert.*;
 
 @Config(constants = BuildConfig.class)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class HabitRPGUserTest {
 
     private HabitRPGUser user;

--- a/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/utils/DateDeserializerTest.java
+++ b/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/utils/DateDeserializerTest.java
@@ -11,7 +11,7 @@ import com.habitrpg.android.habitica.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Type;
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 @Config(constants = BuildConfig.class)
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class DateDeserializerTest {
     DateDeserializer deserializer;
     JsonDeserializationContext deserializationContext;


### PR DESCRIPTION
Previously the AlarmManagerTests were throwing NPEs due to a bug in Robolectric, until @vIiRuS disabled them. 

This change upgrades us to the latest version of Robolectric, fixes things up*, and uncomments the tests since they now all pass.

Ideally I'd like to check all the *ApiTests which also use Robolectric still pass, but I'm not set up to run them locally.. (and I note the Travis build is having npm issues currently? :/)

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14

*From https://github.com/robolectric/robolectric/wiki/3.0-to-3.1-Upgrade-Guide : "RobolectricGradleTestRunner is deprecated and uses should be replaced with RobolectricTestRunner."

Edit: I mistakenly wrote that @TheHollidayInn disabled the tests, but it was actually @vIiRuS , sorry for any confusion! 