### PR TITLE
Fix health bar not restoring immediately on level up

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/helpers/DataBindingUtils.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/helpers/DataBindingUtils.java
@@ -83,11 +83,11 @@ public class DataBindingUtils {
     public static void setLayoutWeight(View view, float weight) {
         view.clearAnimation();
         ValueBarBinding value_bar = DataBindingUtil.findBinding(view);
+        LinearLayout.LayoutParams layout = (LinearLayout.LayoutParams) view.getLayoutParams();
         if (weight == 0.0f || weight == 1.0f || value_bar.getPartyMembers()) {
-            LinearLayout.LayoutParams layout = (LinearLayout.LayoutParams) view.getLayoutParams();
             layout.weight = weight;
             view.setLayoutParams(layout);
-        } else {
+        } else if (layout.weight != weight) {
             LayoutWeightAnimation anim = new LayoutWeightAnimation(view, weight);
             anim.setDuration(1250);
             view.startAnimation(anim);

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/helpers/DataBindingUtils.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/helpers/DataBindingUtils.java
@@ -81,6 +81,7 @@ public class DataBindingUtils {
 
     @BindingAdapter("android:layout_weight")
     public static void setLayoutWeight(View view, float weight) {
+        view.clearAnimation();
         ValueBarBinding value_bar = DataBindingUtil.findBinding(view);
         if (weight == 0.0f || weight == 1.0f || value_bar.getPartyMembers()) {
             LinearLayout.LayoutParams layout = (LinearLayout.LayoutParams) view.getLayoutParams();


### PR DESCRIPTION
See issue #686 for description of the problem. Either of these commits are sufficient to fix it but both seem wise.

What was happening was on level up, setLayoutWeight was called twice in quick succession for the health value bar, the first time with the _same value as its existing value_ , which nonetheless started an animation to bring it to that same level in 1250ms, so when setLayoutWeight was called again with the new (restored) value, this was subsequently overridden by the animation that was previously set, bringing it back down to the previous level.

These commits ensure any ongoing animations are cleared when setLayoutWeight is called and also that we don't bother setting an animation if the layout weight is already as desired.

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14
