### PR TITLE
use-sound-level-of-media-instead-notification

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/SoundFile.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/SoundFile.java
@@ -54,7 +54,7 @@ public class SoundFile implements MediaPlayer.OnCompletionListener {
 
         try {
             mp.setDataSource(path);
-            mp.setAudioStreamType(AudioManager.STREAM_NOTIFICATION);
+            mp.setAudioStreamType(AudioManager.STREAM_MUSIC);
             mp.prepare();
 
             playerPrepared = true;


### PR DESCRIPTION
Using the android app, the volume for music/sound of task completed (when I touch a task checkbox), depends on the volume level of "Notification sound". I would expect the volume of that to depend on the volume of "Music, video, games & other media"

It is very annoying as sometime I check the last tasks in bed just before cron and then the app plays this sound and it wakes my wife :)