### PR TITLE
Issue287/no activity ref in application

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -306,6 +306,5 @@ tasks.whenTaskAdded { task ->
 
 check { findbugs { skip true } }
 
-apply plugin: 'com.android.application' //or apply plugin: 'java'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.google.gms.google-services'

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/HabiticaBaseApplication.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/HabiticaBaseApplication.java
@@ -47,7 +47,6 @@ import dagger.Lazy;
 public abstract class HabiticaBaseApplication extends MultiDexApplication {
 
     public static HabitRPGUser User;
-    public static Activity currentActivity = null;
     private static AppComponent component;
     public RefWatcher refWatcher;
     @Inject
@@ -136,7 +135,6 @@ public abstract class HabiticaBaseApplication extends MultiDexApplication {
         setupFlowManager();
         setupFacebookSdk();
         createBillingAndCheckout();
-        registerActivityLifecycleCallbacks();
 
         if (!BuildConfig.DEBUG) {
             try {
@@ -203,47 +201,6 @@ public abstract class HabiticaBaseApplication extends MultiDexApplication {
         if (fbApiKey != null) {
             FacebookSdk.sdkInitialize(getApplicationContext());
         }
-    }
-
-    private void registerActivityLifecycleCallbacks() {
-        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
-            @Override
-            public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-                HabiticaBaseApplication.currentActivity = activity;
-            }
-
-            @Override
-            public void onActivityStarted(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivityResumed(Activity activity) {
-                HabiticaBaseApplication.currentActivity = activity;
-            }
-
-            @Override
-            public void onActivityPaused(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivityStopped(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-
-            }
-
-            @Override
-            public void onActivityDestroyed(Activity activity) {
-                if (currentActivity.equals(activity)) {
-                    currentActivity = null;
-                }
-            }
-        });
     }
 
     @Override

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/events/commands/ShowConnectionProblemCommand.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/events/commands/ShowConnectionProblemCommand.java
@@ -1,0 +1,16 @@
+package com.habitrpg.android.habitica.events.commands;
+
+/**
+ * Created by maia on 2017/06/04.
+ */
+
+public class ShowConnectionProblemCommand {
+    public String title;
+    public String message;
+
+    public ShowConnectionProblemCommand(String title, String message) {
+        this.title = title;
+        this.message = message;
+
+    }
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManager.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManager.java
@@ -82,7 +82,7 @@ public class PopupNotificationsManager {
         Button confirmButton = (Button) view.findViewById(R.id.confirm_button);
         confirmButton.setTextColor(ContextCompat.getColor(context, R.color.brand_300));
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(HabiticaApplication.currentActivity, R.style.AlertDialogTheme)
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.AlertDialogTheme)
                 .setTitle(title)
                 .setView(view)
                 .setMessage("");
@@ -108,14 +108,6 @@ public class PopupNotificationsManager {
             return false;
         }
 
-        if (HabiticaApplication.currentActivity == null || HabiticaApplication.currentActivity.isFinishing()) {
-            return false;
-        }
-
-        HabiticaApplication.currentActivity.runOnUiThread(() -> {
-            if (HabiticaApplication.currentActivity == null) return;
-            if ((HabiticaApplication.currentActivity).isFinishing()) return;
-
             if (this.seenNotifications == null) {
                 this.seenNotifications = new HashMap<>();
             }
@@ -132,7 +124,6 @@ public class PopupNotificationsManager {
                 this.displayNotification(notification);
                 this.seenNotifications.put(notification.getId(), true);
             }
-        });
 
         return true;
     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/interactors/CheckClassSelectionUseCase.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/interactors/CheckClassSelectionUseCase.java
@@ -2,8 +2,8 @@ package com.habitrpg.android.habitica.interactors;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 
-import com.habitrpg.android.habitica.HabiticaApplication;
 import com.habitrpg.android.habitica.events.SelectClassEvent;
 import com.habitrpg.android.habitica.executors.PostExecutionThread;
 import com.habitrpg.android.habitica.executors.ThreadExecutor;
@@ -35,17 +35,17 @@ public class CheckClassSelectionUseCase extends UseCase<CheckClassSelectionUseCa
                     SelectClassEvent event = new SelectClassEvent();
                     event.isInitialSelection = true;
                     event.currentClass = user.getStats().get_class().toString();
-                    displayClassSelectionActivity(user, event);
+                    displayClassSelectionActivity(requestValues.hostActivity, user, event);
                 }
             } else {
-                displayClassSelectionActivity(user, requestValues.selectClassEvent);
+                displayClassSelectionActivity(requestValues.hostActivity, user, requestValues.selectClassEvent);
             }
 
             return null;
         });
     }
 
-    private void displayClassSelectionActivity(HabitRPGUser user, SelectClassEvent event) {
+    private void displayClassSelectionActivity(AppCompatActivity hostActivity, HabitRPGUser user, SelectClassEvent event) {
         Bundle bundle = new Bundle();
         bundle.putString("size", user.getPreferences().getSize());
         bundle.putString("skin", user.getPreferences().getSkin());
@@ -58,19 +58,20 @@ public class CheckClassSelectionUseCase extends UseCase<CheckClassSelectionUseCa
         bundle.putBoolean("isInitialSelection", event.isInitialSelection);
         bundle.putString("currentClass", event.currentClass);
 
-        Intent intent = new Intent(HabiticaApplication.currentActivity, ClassSelectionActivity.class);
+        Intent intent = new Intent(hostActivity, ClassSelectionActivity.class);
         intent.putExtras(bundle);
-        HabiticaApplication.currentActivity.startActivityForResult(intent, SELECT_CLASS_RESULT);
+        hostActivity.startActivityForResult(intent, SELECT_CLASS_RESULT);
     }
 
     public static final class RequestValues implements UseCase.RequestValues {
 
 
+        private final AppCompatActivity hostActivity;
         private HabitRPGUser user;
         private SelectClassEvent selectClassEvent;
 
-        public RequestValues(HabitRPGUser user, SelectClassEvent selectClassEvent) {
-
+        public RequestValues(AppCompatActivity hostActivity, HabitRPGUser user, SelectClassEvent selectClassEvent) {
+            this.hostActivity = hostActivity;
             this.user = user;
             this.selectClassEvent = selectClassEvent;
         }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/interactors/LevelUpUseCase.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/interactors/LevelUpUseCase.java
@@ -43,7 +43,7 @@ public class LevelUpUseCase extends UseCase<LevelUpUseCase.RequestValues, Stats>
             SuppressedModals suppressedModals = requestValues.user.getPreferences().getSuppressModals();
             if (suppressedModals != null) {
                 if (suppressedModals.getLevelUp()) {
-                    checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(requestValues.user, null))
+                    checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(requestValues.compatActivity, requestValues.user, null))
                             .subscribe(aVoid -> {
                             }, throwable -> {
                             });
@@ -70,7 +70,7 @@ public class LevelUpUseCase extends UseCase<LevelUpUseCase.RequestValues, Stats>
                     .setTitle(R.string.levelup_header)
                     .setView(customView)
                     .setPositiveButton(R.string.levelup_button, (dialog, which) -> {
-                        checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(requestValues.user, null))
+                        checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(requestValues.compatActivity, requestValues.user, null))
                                 .subscribe(aVoid -> {
                                 }, throwable -> {
                                 });

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/MaxHeightLinearLayout.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/MaxHeightLinearLayout.java
@@ -1,9 +1,6 @@
 package com.habitrpg.android.habitica.ui;
 
 
-import com.habitrpg.android.habitica.HabiticaApplication;
-import com.habitrpg.android.habitica.R;
-
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -11,7 +8,10 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.LinearLayout;
+
+import com.habitrpg.android.habitica.R;
 
 public class MaxHeightLinearLayout extends LinearLayout {
 
@@ -58,12 +58,12 @@ public class MaxHeightLinearLayout extends LinearLayout {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 
-        if (HabiticaApplication.currentActivity != null) {
-            HabiticaApplication.currentActivity.getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-            int height = (int) (displaymetrics.heightPixels * maxHeight);
+        WindowManager windowManager = (WindowManager) getContext()
+                .getSystemService(Context.WINDOW_SERVICE);
+        windowManager.getDefaultDisplay().getMetrics(displaymetrics);
+        int height = (int) (displaymetrics.heightPixels * maxHeight);
 
-            heightMeasureSpec = Math.min(heightMeasureSpec, View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.AT_MOST));
-        }
+        heightMeasureSpec = Math.min(heightMeasureSpec, View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.AT_MOST));
 
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/BaseActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/BaseActivity.java
@@ -2,15 +2,21 @@ package com.habitrpg.android.habitica.ui.activities;
 
 import com.habitrpg.android.habitica.HabiticaApplication;
 import com.habitrpg.android.habitica.HabiticaBaseApplication;
+import com.habitrpg.android.habitica.R;
 import com.habitrpg.android.habitica.components.AppComponent;
+import com.habitrpg.android.habitica.events.commands.ShowConnectionProblemCommand;
 
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
 
 import butterknife.ButterKnife;
 
@@ -51,6 +57,18 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
+    protected void onStop() {
+        EventBus.getDefault().unregister(this);
+        super.onStop();
+    }
+
+    @Override
     protected void onDestroy() {
         destroyed = true;
         super.onDestroy();
@@ -83,5 +101,19 @@ public abstract class BaseActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
+    @Subscribe
+    public void onEvent(ShowConnectionProblemCommand event) {
 
+        AlertDialog.Builder builder = new AlertDialog.Builder(this)
+                .setTitle(event.title)
+                .setMessage(event.message)
+                .setNeutralButton(android.R.string.ok, (dialog, which) -> {
+                });
+
+        if (!event.title.isEmpty()) {
+            builder.setIcon(R.drawable.ic_warning_black);
+        }
+
+        builder.show();
+    }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.java
@@ -183,11 +183,11 @@ public class FullProfileActivity extends BaseActivity {
                             }, throwable -> {
                             });
 
-                    UiUtils.dismissKeyboard(HabiticaApplication.currentActivity);
+                    UiUtils.dismissKeyboard(this);
                 })
                 .setNegativeButton(android.R.string.cancel, (dialogInterface, i) -> {
 
-                    UiUtils.dismissKeyboard(HabiticaApplication.currentActivity);
+                    UiUtils.dismissKeyboard(this);
                 })
 
                 .create();

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
@@ -258,7 +258,7 @@ public class MainActivity extends BaseActivity implements Action1<Throwable>, Ha
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        RemoteConfigManager remoteConfigManager = RemoteConfigManager.getInstance(this);
+        RemoteConfigManager.loadConfig(this);
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         LanguageHelper languageHelper = new LanguageHelper(sharedPreferences.getString("language", "en"));
@@ -302,8 +302,6 @@ public class MainActivity extends BaseActivity implements Action1<Throwable>, Ha
             float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16, getResources().getDisplayMetrics());
             avatar_with_bars.setPadding((int)px, getStatusBarHeight(), (int)px, 0);
         }
-
-        EventBus.getDefault().register(this);
     }
 
     public int getStatusBarHeight() {
@@ -705,12 +703,6 @@ public class MainActivity extends BaseActivity implements Action1<Throwable>, Ha
 
     // region Events
 
-    @Override
-    public void onDestroy() {
-        EventBus.getDefault().unregister(this);
-        super.onDestroy();
-    }
-
     @Subscribe
     public void onEvent(ToggledInnStateEvent evt) {
         avatarInHeader.updateData(user);
@@ -1090,7 +1082,7 @@ public class MainActivity extends BaseActivity implements Action1<Throwable>, Ha
 
     @Subscribe
     public void displayClassSelectionActivity(SelectClassEvent event) {
-        checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(user, event))
+        checkClassSelectionUseCase.observable(new CheckClassSelectionUseCase.RequestValues(this, user, event))
                 .subscribe(aVoid -> {
                 }, throwable -> {
                 });

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/SetupActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/SetupActivity.java
@@ -128,18 +128,6 @@ public class SetupActivity extends BaseActivity implements ViewPager.OnPageChang
         component.inject(this);
     }
 
-    @Override
-    protected void onStart() {
-        super.onStart();
-        EventBus.getDefault().register(this);
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        EventBus.getDefault().unregister(this);
-    }
-
     private void setupViewpager() {
         android.support.v4.app.FragmentManager fragmentManager = getSupportFragmentManager();
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/SkillMemberActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/SkillMemberActivity.java
@@ -39,9 +39,6 @@ public class SkillMemberActivity extends BaseActivity {
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        EventBus.getDefault().register(this);
-
         loadMemberList();
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/social/AchievementAdapter.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/social/AchievementAdapter.java
@@ -130,9 +130,9 @@ public class AchievementAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
         @Override
         public void onClick(View view) {
-            AlertDialog.Builder b = new AlertDialog.Builder(HabiticaApplication.currentActivity);
+            AlertDialog.Builder b = new AlertDialog.Builder(view.getContext());
 
-            View customView = LayoutInflater.from(itemView.getContext())
+            View customView = LayoutInflater.from(view.getContext())
                     .inflate(R.layout.dialog_achievement_details, null);
             ImageView achievementImage = (ImageView) customView.findViewById(R.id.achievement_image);
             achievementImage.setImageDrawable(draweeView.getDrawable());

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
@@ -36,32 +36,7 @@ public abstract class BaseFragment extends DialogFragment {
     public String tutorialText;
     public Unbinder unbinder;
     protected boolean tutorialCanBeDeferred = true;
-    private TransactionListener<TutorialStep> tutorialStepTransactionListener = new TransactionListener<TutorialStep>() {
-        @Override
-        public void onResultReceived(TutorialStep step) {
-            if (step != null && step.shouldDisplay()) {
-                DisplayTutorialEvent event = new DisplayTutorialEvent();
-                event.step = step;
-                if (tutorialText != null) {
-                    event.tutorialText = tutorialText;
-                } else {
-                    event.tutorialTexts = tutorialTexts;
-                }
-                event.canBeDeferred = tutorialCanBeDeferred;
-                EventBus.getDefault().post(event);
-            }
-        }
-
-        @Override
-        public boolean onReady(BaseTransaction<TutorialStep> baseTransaction) {
-            return true;
-        }
-
-        @Override
-        public boolean hasResult(BaseTransaction<TutorialStep> baseTransaction, TutorialStep step) {
-            return true;
-        }
-    };
+    private TutorialStepTransactionListener tutorialStepTransactionListener;
     public List<String> tutorialTexts;
 
     @Override
@@ -91,7 +66,7 @@ public abstract class BaseFragment extends DialogFragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-
+        tutorialStepTransactionListener = new TutorialStepTransactionListener();
         // Receive Events
         try {
             EventBus.getDefault().register(this);
@@ -123,7 +98,7 @@ public abstract class BaseFragment extends DialogFragment {
             unbinder.unbind();
             unbinder = null;
         }
-
+        tutorialStepTransactionListener = null;
         super.onDestroyView();
         RefWatcher refWatcher = HabiticaApplication.getInstance(getContext()).refWatcher;
         refWatcher.watch(this);
@@ -131,6 +106,33 @@ public abstract class BaseFragment extends DialogFragment {
 
     public String getDisplayedClassName() {
         return this.getClass().getSimpleName();
+    }
+
+    private class TutorialStepTransactionListener implements TransactionListener<TutorialStep> {
+        @Override
+        public void onResultReceived(TutorialStep step) {
+            if (step != null && step.shouldDisplay()) {
+                DisplayTutorialEvent event = new DisplayTutorialEvent();
+                event.step = step;
+                if (tutorialText != null) {
+                    event.tutorialText = tutorialText;
+                } else {
+                    event.tutorialTexts = tutorialTexts;
+                }
+                event.canBeDeferred = tutorialCanBeDeferred;
+                EventBus.getDefault().post(event);
+            }
+        }
+
+        @Override
+        public boolean onReady(BaseTransaction<TutorialStep> baseTransaction) {
+            return true;
+        }
+
+        @Override
+        public boolean hasResult(BaseTransaction<TutorialStep> baseTransaction, TutorialStep step) {
+            return true;
+        }
     }
 
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -438,6 +438,9 @@ public class TasksFragment extends BaseMainFragment {
 
     @Override
     public void onDestroyView() {
+        if (bottomNavigation != null) {
+            bottomNavigation.removeOnTabSelectListener();
+        }
         super.onDestroyView();
     }
 

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManagerTest.java
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/helpers/PopupNotificationsManagerTest.java
@@ -72,9 +72,6 @@ public class PopupNotificationsManagerTest {
     @Test
     // @TODO: Eventually, we should have a list of implemented notifications and only use those
     public void itShouldNotDisplayNotificationsThatAreNotLoginIncentives() {
-        Activity activity;
-        activity = Robolectric.buildActivity(Activity.class).create().get();
-        HabiticaApplication.currentActivity = activity;
 
         List<Notification> notifications = new ArrayList<>();
 
@@ -94,9 +91,6 @@ public class PopupNotificationsManagerTest {
 
     @Test
     public void itShouldDisplayADialogueForANotification() {
-        Activity activity;
-        activity = Robolectric.buildActivity(Activity.class).create().get();
-        HabiticaApplication.currentActivity = activity;
 
         String testTitle = "Test Title";
 
@@ -122,9 +116,6 @@ public class PopupNotificationsManagerTest {
 
     @Test
     public void itShouldNotDisplayANotificationTwice() {
-        Activity activity;
-        activity = Robolectric.buildActivity(Activity.class).create().get();
-        HabiticaApplication.currentActivity = activity;
 
         String testTitle = "Test Title";
 


### PR DESCRIPTION
Assorted memory leak fixes:
The biggest one was removing the reference to an activity from the application. Multiple leak canary leaks were appearing because of this.  I reran all of the UseCase tests and the PopupNotificationManager tests and they passed after the change.

Also I made the RemoteConfig not be a singleton and rather replaced with just method calls. From the existing code a singleton isn't needed. I left some comments in there because I don't understand the history or intention of this so maybe we want it back.

I moved the eventbus register and unregister into the basefragment so we know it is always called.

This does not close Issue 287. There are still some more leaks I am seeing with Leak Canary but I it is looking much better.

I tested by putting breakpoints in the code I changed and going to that part of the app manually. This does not mean I haven't broken anything. We probably need to do a thorough test.

my Habitica User-ID: c34cbae3-a66f-4211-884f-0c90d48d71fc
