### PR TITLE
Add missing property "STAGING_KEY" for builds on example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.3
+    - build-tools-26.0.1
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
     - extra-google-google_play_services

--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -138,8 +138,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion sdk_version
+    buildToolsVersion build_tools_version
 
     defaultConfig {
         applicationId "com.habitrpg.android.habitica"
@@ -181,6 +181,7 @@ android {
     productFlavors {
         dev {
             minSdkVersion 21
+            buildConfigField "String", "STAGING_KEY", "\"1dcf9ed3-3b14-45b3-9e7e-acdfff68a368\""
         }
 
         prod {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     ext.kotlin_version = '1.1.51'
+    ext.build_tools_version = '26.0.1'
+    ext.sdk_version = 26
+
     repositories {
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }

--- a/habitica.properties.example
+++ b/habitica.properties.example
@@ -12,3 +12,4 @@ PORT=80
 
 # Production
 BASE_URL=https://habitica.com
+STAGING_KEY=the-key

--- a/habitica.properties.travis
+++ b/habitica.properties.travis
@@ -1,2 +1,3 @@
 PORT=3000
 BASE_URL=http://localhost:3000
+STAGING_KEY=the-key

--- a/seeds-sdk/build.gradle
+++ b/seeds-sdk/build.gradle
@@ -28,9 +28,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-
-    buildToolsVersion "25.0.3"
+    compileSdkVersion sdk_version
+    buildToolsVersion build_tools_version
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
The current setup needs a the variable `STAGING_KEY` on the `BuildConfig` class but it not documented on the example.

This PR try to:
- Fix `STAGING_KEY` doc issue.
- Fix each project use different sdk version setup ending up in conflicts with travis setup sometimes if not updated correctly, so this makes each module to use the same sdk version.

my Habitica User-ID: 6a5dcf62-46d7-41f6-b4a5-19b1bc8a3784

