### PR TITLE
Add confirmation step to "begin" button for quests. Fixes #804

### DIFF
--- a/Habitica/res/values-bg/strings.xml
+++ b/Habitica/res/values-bg/strings.xml
@@ -272,7 +272,6 @@
   <string name="equipped">Екипирано</string>
   <string name="quest_cancel_message">Наистина ли искате да прекратите мисията? Всички приети покани ще бъдат загубени. Притежателят на мисията ще си запази свитъка ѝ.</string>
   <string name="quest.invitation">Покана за мисия</string>
-  <string name="quest_begin_message">Наистина ли искате да започнете мисията? След като мисията започне, никой повече няма да може да се присъедини към нея.</string>
   <string name="quest.invitation.text">Получихте покана за участие в мисия!</string>
   <string name="ago_1day">Преди 1 ден</string>
   <string name="ago_days">Преди %d дни</string>

--- a/Habitica/res/values-de/strings.xml
+++ b/Habitica/res/values-de/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">Ausgerüstet</string>
   <string name="quest_cancel_message">Bist Du sicher, dass Du diese Quest abbrechen willst? Alle angenommenen Einladungen gehen verloren. Der Questbesitzer erhält die Questschriftrolle zurück.</string>
   <string name="quest.invitation">Questeinladung</string>
-  <string name="quest_begin_message">Bist Du sicher, dass Du die Quest beginnen willst? Sobald sie aktiv ist, können keine zusätzlichen Gruppenmitglieder beitreten.</string>
-  <string name="quest.invitation.text">Du wurdest eingeladen, an einer Quest teilzunehmen!</string>
+    <string name="quest.invitation.text">Du wurdest eingeladen, an einer Quest teilzunehmen!</string>
   <string name="ago_1day">Vor einem Tag</string>
   <string name="ago_days">Vor %d Tagen</string>
   <string name="ago_1Minute">Vor einer Minute</string>

--- a/Habitica/res/values-en-rGB/strings.xml
+++ b/Habitica/res/values-en-rGB/strings.xml
@@ -272,7 +272,7 @@
   <string name="equipped">Equipped</string>
   <string name="quest_cancel_message">Are you sure you want to cancel this quest? All invitation acceptances will be lost. The quest owner will retain possession of the quest scroll.</string>
   <string name="quest.invitation">Quest Invitation</string>
-  <string name="quest_begin_message">Are you sure you want to begin the quest? Once it is active, no additional party members can join the quest.</string>
+  <string name="quest_begin_message">Are you sure? Only %1$d of your %2$d party members have joined this quest! Quests start automatically when all players have joined or rejected the invitation.</string>
   <string name="quest.invitation.text">You have been invited to participate in a quest!</string>
   <string name="ago_1day">1 day ago</string>
   <string name="ago_days">%d days ago</string>

--- a/Habitica/res/values-es/strings.xml
+++ b/Habitica/res/values-es/strings.xml
@@ -243,7 +243,7 @@
   <string name="equipped">Equipado</string>
   <string name="quest_cancel_message">¿Seguro que quieres cancelar esta misión? Se perderán todas las invitaciones que se hayan aceptado y el propietario de la misión recuperará el pergamino.</string>
   <string name="quest.invitation">Invitación a misión</string>
-  <string name="quest_begin_message">¿Seguro que quieres comenzar la misión? Una vez comenzada, no podrán unirse a esta misión más miembros del grupo.</string>
+  <string name="quest_begin_message">¿Estás seguro? Solamente %1$d de %2$d miembros de tu grupo se han unido a la misión! Las misiones comienzan automaticamente cuando todos los jugadores se han unido o han rechazado la invitación.</string>
   <string name="quest.invitation.text">Te han invitado a participar en una misión.</string>
   <string name="ago_1day">Hace 1 día</string>
   <string name="ago_days">Hace %d días</string>

--- a/Habitica/res/values-fr/strings.xml
+++ b/Habitica/res/values-fr/strings.xml
@@ -272,7 +272,6 @@
   <string name="equipped">Équipé</string>
   <string name="quest_cancel_message">Êtes-vous sûr·e de vouloir annuler cette quête ? Toutes les invitations ayant été acceptées seront perdues. Le lanceur de la quête gardera le parchemin de la quête en sa possession.</string>
   <string name="quest.invitation">Invitation à une quête</string>
-  <string name="quest_begin_message">Êtes-vous sûr·e de vouloir commencer la quête ? Une fois lancée, aucun autre membre de l\'équipe ne peut rejoindre la quête.</string>
   <string name="quest.invitation.text">Vous avez été invité·e à participer à une quête !</string>
   <string name="ago_1day">il y a 1 jour</string>
   <string name="ago_days">il y a %d jours</string>

--- a/Habitica/res/values-hr-rHR/strings.xml
+++ b/Habitica/res/values-hr-rHR/strings.xml
@@ -218,8 +218,7 @@
   <string name="equipped">Opremljeno</string>
   <string name="quest_cancel_message">Jesi li siguran da želiš otkazati ovaj pothvat? Svi prihvati pozivnica će biti izgubljeni. Vlasnik pothvata će dobiti natrag svitak Pothvata</string>
   <string name="quest.invitation">Pozivnica za Pothvat</string>
-  <string name="quest_begin_message">Jesi li siguran da želiš započeti pothvat? Jednom kad je aktivan, članovi grupe se ne mogu pridružiti.</string>
-  <string name="quest.invitation.text">Pozvani ste na sudjelovanje u pothvatu!</string>
+    <string name="quest.invitation.text">Pozvani ste na sudjelovanje u pothvatu!</string>
   <string name="ago_1day">Prije 1 dan</string>
   <string name="ago_days">Prije %d dana </string>
   <string name="ago_1Minute">Prije 1 minute </string>

--- a/Habitica/res/values-in/strings.xml
+++ b/Habitica/res/values-in/strings.xml
@@ -243,8 +243,7 @@
   <string name="equipped">Digunakan</string>
   <string name="quest_cancel_message">Apakah kamu yakin kamu ingin membatalkan misi ini? Semua undangan yang disetujui akan hilang. Pemilik misi akan mendapatkan gulungan misi kembali.</string>
   <string name="quest.invitation">Undangan Misi</string>
-  <string name="quest_begin_message">Apakah kamu yakin kamu ingin memulai misi? Setelah aktif, tidak ada anggota kelompok lain yang dapat bergabung.</string>
-  <string name="quest.invitation.text">Kamu telah diundang untuk berpartisipasi dalam misi!</string>
+    <string name="quest.invitation.text">Kamu telah diundang untuk berpartisipasi dalam misi!</string>
   <string name="ago_1day">1 hari yang lalu</string>
   <string name="ago_days">%d hari yang lalu</string>
   <string name="ago_1Minute">1 menit yang lalu</string>

--- a/Habitica/res/values-it/strings.xml
+++ b/Habitica/res/values-it/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">Equipaggiato</string>
   <string name="quest_cancel_message">Vuoi davvero annullare questa missione? Tutti gli inviti accettati andranno persi. Il proprietario della missione tornerà in possesso della Pergamena.</string>
   <string name="quest.invitation">Invito Missione</string>
-  <string name="quest_begin_message">Vuoi davvero iniziare la missione? Una volta attiva, nessun altro membro della squadra potrà unirsi alla missione.</string>
-  <string name="quest.invitation.text">Sei stato invitato a partecipare ad una missione!</string>
+    <string name="quest.invitation.text">Sei stato invitato a partecipare ad una missione!</string>
   <string name="ago_1day">1 giorno fa</string>
   <string name="ago_days">%d giorni fa</string>
   <string name="ago_1Minute">1 minuto fa</string>

--- a/Habitica/res/values-iw/strings.xml
+++ b/Habitica/res/values-iw/strings.xml
@@ -235,8 +235,7 @@
   <string name="equipped">מצוייד</string>
   <string name="quest_cancel_message">האם אתם בטוחים שאתם מעוניינים להפסיק את ההרפתקאה הזו? כל אישורי ההזמנות יאבדו. הבעלים של ההרפתקאה ימשיכו להחזיק במגילת ההרפתקאה.</string>
   <string name="quest.invitation">הזמנה להרפתקאה</string>
-  <string name="quest_begin_message">האם אתם בטוחים שאתם מעוניינים להתחיל בהרפתקאה? ברגע שהיא מתחילה, חברי חבורה נוספים לא יכולים להצטרף אליה.</string>
-  <string name="quest.invitation.text">הוזמנתם להשתתף בהרפתקאה!</string>
+    <string name="quest.invitation.text">הוזמנתם להשתתף בהרפתקאה!</string>
   <string name="ago_1day">לפני יום</string>
   <string name="ago_days">לפני %d ימים</string>
   <string name="ago_1Minute">לפני דקה</string>

--- a/Habitica/res/values-ja/strings.xml
+++ b/Habitica/res/values-ja/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">装備済み</string>
   <string name="quest_cancel_message">このクエストを中止します。よろしいですか?　招待を受けたすべての参加者を失うことになります。クエストの所有者の元にクエストの巻物が戻ってきます。</string>
   <string name="quest.invitation">クエストへの招待</string>
-  <string name="quest_begin_message">クエストをはじめます。よろしいですか?　クエストを開始すると、新たにメンバーがクエストに参加することはできません。</string>
-  <string name="quest.invitation.text">クエストへの招待状が届いた!</string>
+    <string name="quest.invitation.text">クエストへの招待状が届いた!</string>
   <string name="ago_1day">1日前</string>
   <string name="ago_days">%d日前</string>
   <string name="ago_1Minute">1分前</string>

--- a/Habitica/res/values-ko/strings.xml
+++ b/Habitica/res/values-ko/strings.xml
@@ -275,8 +275,7 @@
   <string name="equipped">착용됨</string>
   <string name="quest_cancel_message">정말 이 퀘스트를 취소하시겠습니까? 모든 초대장과 승인들을 잃을 것입니다. 퀘스트 스크롤은 주인에게 돌아갑니다.</string>
   <string name="quest.invitation">퀘스트 초대장</string>
-  <string name="quest_begin_message">정말 이 퀘스트를 시작하시겠습니까? 시작 후 더이상 새로운 파티 멤버가 참여할 수 없습니다.</string>
-  <string name="quest.invitation.text">퀘스트에 초대받았습니다!</string>
+    <string name="quest.invitation.text">퀘스트에 초대받았습니다!</string>
   <string name="ago_1day">하루 전</string>
   <string name="ago_days">%d 일 전</string>
   <string name="ago_1Minute">1분 전</string>

--- a/Habitica/res/values-lt/strings.xml
+++ b/Habitica/res/values-lt/strings.xml
@@ -242,8 +242,7 @@
   <string name="equipped">Užsidėta</string>
   <string name="quest_cancel_message">Ar tikrai nori atšaukti misiją? Visi pakvietimai bus nutraukti. Misijos savininkas atgaus misijos rankraštį.</string>
   <string name="quest.invitation">Misijos Pakvietimas</string>
-  <string name="quest_begin_message">Ar tikrai nori pradėti misiją? Kai ji prasidės, kiti grupės nariai nebegalės prisijungti.</string>
-  <string name="quest.invitation.text">Tave pakvietė dalyvauti misijoje!</string>
+    <string name="quest.invitation.text">Tave pakvietė dalyvauti misijoje!</string>
   <string name="ago_1day">Liko 1 diena</string>
   <string name="ago_days">prieš %d dieną(as)</string>
   <string name="ago_1Minute">prieš 1 minutę</string>

--- a/Habitica/res/values-nl/strings.xml
+++ b/Habitica/res/values-nl/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">In gebruik</string>
   <string name="quest_cancel_message">Ben je zeker dat je deze queeste wilt beëindigen? Alle aangenomen uitnodigingen zullen verloren gaan. De eigenaar van de queeste zal de queesterol terug krijgen.</string>
   <string name="quest.invitation">Queeste uitnodiging</string>
-  <string name="quest_begin_message">Ben je zeker dat je de queeste wilt beginnen? Zodra het actief is, kunnen er geen andere spelers zich bij de queeste aansluiten.</string>
-  <string name="quest.invitation.text">Je bent uitgenodigd om deel te nemen aan een queeste!</string>
+    <string name="quest.invitation.text">Je bent uitgenodigd om deel te nemen aan een queeste!</string>
   <string name="ago_1day">1 dag geleden</string>
   <string name="ago_days">%d dagen geleden</string>
   <string name="ago_1Minute">1 minuut geleden</string>

--- a/Habitica/res/values-pl/strings.xml
+++ b/Habitica/res/values-pl/strings.xml
@@ -269,8 +269,7 @@
   <string name="equipped">W użyciu</string>
   <string name="quest_cancel_message">Jesteś pewien że chcesz przerwać quest? Quest zostanie przerwany dla wszystkich uczestników. Zwołujący quest odzyska skrypt (quest scroll).</string>
   <string name="quest.invitation">Zaproszenie do questa.</string>
-  <string name="quest_begin_message">Czy jesteś pewien, ze chcesz zacząć misję? Gdy zostanie aktywowana, żaden dodatkowy członek drużyny nie będzie mógł do niej dołączyc.</string>
-  <string name="quest.invitation.text">Zostałeś zaproszony do udziału w misji!</string>
+    <string name="quest.invitation.text">Zostałeś zaproszony do udziału w misji!</string>
   <string name="ago_1day">1 dzień temu</string>
   <string name="ago_days">%d dni temu</string>
   <string name="ago_1Minute">1 minutę temu</string>

--- a/Habitica/res/values-pt-rBR/strings.xml
+++ b/Habitica/res/values-pt-rBR/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">Equipado</string>
   <string name="quest_cancel_message">Tem certeza que deseja cancelar esta missão? Todas os convites aceitos serão perdidos. O proprietário da missão manterá posse do pergaminho da missão.</string>
   <string name="quest.invitation">Convite para Missão</string>
-  <string name="quest_begin_message">Tem certeza que deseja começar a missão? Uma vez ativa, outros membros do grupo não poderão juntar-se à missão.</string>
-  <string name="quest.invitation.text">Você foi convidado a participar de uma missão!</string>
+    <string name="quest.invitation.text">Você foi convidado a participar de uma missão!</string>
   <string name="ago_1day">1 dia atrás</string>
   <string name="ago_days">%d dias atrás</string>
   <string name="ago_1Minute">1 minuto atrás</string>

--- a/Habitica/res/values-pt-rPT/strings.xml
+++ b/Habitica/res/values-pt-rPT/strings.xml
@@ -255,8 +255,7 @@
   <string name="equipped">Equipado</string>
   <string name="quest_cancel_message">Tem a certeza que deseja cancelar esta missão? Todos os convites aceites serão perdidos. O dono da missão manterá a posse do pergaminho da missão.</string>
   <string name="quest.invitation">Convite de Missão</string>
-  <string name="quest_begin_message">Tem a certeza que pretende iniciar a missão? Assim que esta seja iniciada, nenhum membro da equipa adicional pode juntar-se à missão.</string>
-  <string name="quest.invitation.text">Foi convidado para participar numa missão!</string>
+    <string name="quest.invitation.text">Foi convidado para participar numa missão!</string>
   <string name="ago_1day">Há 1 dia</string>
   <string name="ago_days">Há %d dias</string>
   <string name="ago_1Minute">Há 1 minuto</string>

--- a/Habitica/res/values-ru/strings.xml
+++ b/Habitica/res/values-ru/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">Надето</string>
   <string name="quest_cancel_message">Вы уверены, что хотите отменить квест? Все принятые приглашения будут отменены. Квестовый свиток останется у владельца.</string>
   <string name="quest.invitation">Приглашение в квест</string>
-  <string name="quest_begin_message">Вы уверены, что хотите начать квест? Никто больше не сможет присоединиться к нему.</string>
-  <string name="quest.invitation.text">Вас пригласили в квест!</string>
+    <string name="quest.invitation.text">Вас пригласили в квест!</string>
   <string name="ago_1day">1 день назад</string>
   <string name="ago_days">%d дней назад</string>
   <string name="ago_1Minute">1 минуту назад</string>

--- a/Habitica/res/values-tr/strings.xml
+++ b/Habitica/res/values-tr/strings.xml
@@ -272,8 +272,7 @@
   <string name="equipped">Giyilmiş</string>
   <string name="quest_cancel_message">Bu görevi iptal etmek istediğinize emin misiniz?  Tüm davet kabulleri kaybolacak. Görev sahibi görev parşömeni sahipliğini sürdürecektir.</string>
   <string name="quest.invitation">Görev Daveti</string>
-  <string name="quest_begin_message">Göreve başlamak istediğinize emin misiniz? Bir görev aktif ederseniz, ilave takım üyesi göreve katılamayacaktır.</string>
-  <string name="quest.invitation.text">Göreve katılmak için davet edildin!</string>
+    <string name="quest.invitation.text">Göreve katılmak için davet edildin!</string>
   <string name="ago_1day">1 gün önce</string>
   <string name="ago_days">%d gün önce</string>
   <string name="ago_1Minute">1 dakika önce</string>

--- a/Habitica/res/values-zh-rTW/strings.xml
+++ b/Habitica/res/values-zh-rTW/strings.xml
@@ -246,8 +246,7 @@
   <string name="equipped">裝備</string>
   <string name="quest_cancel_message">你確定要取消任務? 所有邀請將會消失，任務擁有者會收到退還的任務卷軸</string>
   <string name="quest.invitation">任務邀請</string>
-  <string name="quest_begin_message">準備好開始任務了嗎?開始後就無法加入新成員了</string>
-  <string name="quest.invitation.text">你已經被邀請加入任務!</string>
+    <string name="quest.invitation.text">你已經被邀請加入任務!</string>
   <string name="ago_1day">1 天前</string>
   <string name="ago_days">%d 天前</string>
   <string name="ago_1Minute">1 分鐘之前</string>

--- a/Habitica/res/values-zh/strings.xml
+++ b/Habitica/res/values-zh/strings.xml
@@ -254,8 +254,7 @@
   <string name="equipped">装备</string>
   <string name="quest_cancel_message">你是否确定要放弃这个探索任务？这将会失去所有已接受的邀请。探索任务拥有者将拿回探索任务卷轴。</string>
   <string name="quest.invitation">任务邀请</string>
-  <string name="quest_begin_message">你是否确定要直接开始这个探索任务？一旦开始，其他队伍成员就不能加入这个探索任务。</string>
-  <string name="quest.invitation.text">你被邀请参加一个探索任务！</string>
+    <string name="quest.invitation.text">你被邀请参加一个探索任务！</string>
   <string name="ago_1day">1天前</string>
   <string name="ago_days">%d天前</string>
   <string name="ago_1Minute">1分钟前</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -299,9 +299,7 @@
     <string name="equipped">Equipped</string>
     <string name="quest_cancel_message">Are you sure you want to cancel this quest? All invitation acceptances will be lost. The quest owner will retain possession of the quest scroll.</string>
     <string name="quest.invitation">Quest Invitation</string>
-    <string name="quest_begin_message">Are you sure you want to begin the quest? Once it is active, no additional party members can join the quest.</string>
-    <!--TODO quest_begin_message_2 for every translation-->
-    <string name="quest_begin_message_2">Are you sure? Only %1$d of your %2$d party members have joined this quest! Quests start automatically when all players have joined or rejected the invitation.</string>
+    <string name="quest_begin_message">Are you sure? Only %1$d of your %2$d party members have joined this quest! Quests start automatically when all players have joined or rejected the invitation.</string>
     <string name="quest.invitation.text">You have been invited to participate in a quest!</string>
     <string name="ago_1day">1 day ago</string>
     <string name="ago_days" >%d days ago</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -300,6 +300,8 @@
     <string name="quest_cancel_message">Are you sure you want to cancel this quest? All invitation acceptances will be lost. The quest owner will retain possession of the quest scroll.</string>
     <string name="quest.invitation">Quest Invitation</string>
     <string name="quest_begin_message">Are you sure you want to begin the quest? Once it is active, no additional party members can join the quest.</string>
+    <!--TODO quest_begin_message_2 for every translation-->
+    <string name="quest_begin_message_2">Are you sure? Only %1$d of your %2$d party members have joined this quest! Quests start automatically when all players have joined or rejected the invitation.</string>
     <string name="quest.invitation.text">You have been invited to participate in a quest!</string>
     <string name="ago_1day">1 day ago</string>
     <string name="ago_days" >%d days ago</string>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/QuestDetailFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/QuestDetailFragment.java
@@ -206,7 +206,7 @@ public class QuestDetailFragment extends BaseMainFragment {
         } else {
             participantHeader.setText(R.string.invitations);
             participantHeaderCount.setText(participantCount + "/" + quest.participants.size());
-            begin_quest_message = getString(R.string.quest_begin_message_2, participantCount, quest.participants.size());
+            begin_quest_message = getString(R.string.quest_begin_message, participantCount, quest.participants.size());
         }
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/QuestDetailFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/QuestDetailFragment.java
@@ -81,6 +81,7 @@ public class QuestDetailFragment extends BaseMainFragment {
     public String questKey;
     private Group party;
     private Quest quest;
+    private String begin_quest_message;
 
 
     @Nullable
@@ -205,6 +206,7 @@ public class QuestDetailFragment extends BaseMainFragment {
         } else {
             participantHeader.setText(R.string.invitations);
             participantHeaderCount.setText(participantCount + "/" + quest.participants.size());
+            begin_quest_message = getString(R.string.quest_begin_message_2, participantCount, quest.participants.size());
         }
     }
 
@@ -230,7 +232,7 @@ public class QuestDetailFragment extends BaseMainFragment {
     @OnClick(R.id.quest_begin_button)
     public void onQuestBegin() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
-                .setMessage(R.string.quest_begin_message)
+                .setMessage(begin_quest_message)
                 .setPositiveButton(R.string.yes, (dialog, which) -> socialRepository.forceStartQuest(party)
                         .subscribe(quest -> {}, RxErrorHandler.handleEmptyError()))
                 .setNegativeButton(R.string.no, (dialog, which) -> {});


### PR DESCRIPTION
- Changed`quest_begin_message` and had to delete translations because they caused problem with the format string.
- In `QuestDetailFragment.java` I created a global variable `quest_begin_message` which contains the string with the 'participantCount' and 'participants.size()' information formatted.

Fixes #804 

my Habitica User-ID: 4a5d7afb-d65e-485b-8e46-c9414a43b0bb
