### PR TITLE
Fixed showing empty screen on back press

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.java
@@ -365,7 +365,11 @@ public class MainActivity extends BaseActivity implements TutorialView.OnTutoria
         } else {
             FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
             transaction.setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out, android.R.anim.fade_in, android.R.anim.fade_out);
-            transaction.replace(R.id.fragment_container, fragment).addToBackStack(null).commitAllowingStateLoss();
+            transaction.replace(R.id.fragment_container, fragment);
+            if (fragment.addToBackStack()) {
+                transaction.addToBackStack(null);
+            }
+            transaction.commitAllowingStateLoss();
         }
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
@@ -137,4 +137,8 @@ public abstract class BaseFragment extends DialogFragment {
     public String getDisplayedClassName() {
         return this.getClass().getSimpleName();
     }
+
+    public boolean addToBackStack() {
+        return true;
+    }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -467,4 +467,9 @@ public class TasksFragment extends BaseMainFragment {
     public String customTitle() {
         return null;
     }
+
+    @Override
+    public boolean addToBackStack() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #832

So, blank screen is showing because all fragments you open are added to backstack. This fix  works for all 4 main screen fragments, accessed from bottom navigator.

Habitica User-ID: 8eea96e0-042c-44f4-b589-e3177f59bcdd
