### PR TITLE
Don't show like button in messages

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/social/ChatRecyclerViewAdapter.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/social/ChatRecyclerViewAdapter.java
@@ -38,6 +38,7 @@ import rx.subjects.PublishSubject;
 public class ChatRecyclerViewAdapter extends RealmRecyclerViewAdapter<ChatMessage, ChatRecyclerViewAdapter.ChatRecyclerViewHolder> {
 
     private User user;
+    private boolean isTavern;
     private String uuid;
     private User sendingUser;
 
@@ -49,9 +50,10 @@ public class ChatRecyclerViewAdapter extends RealmRecyclerViewAdapter<ChatMessag
     private PublishSubject<ChatMessage> copyMessageAsTodoEvents = PublishSubject.create();
     private PublishSubject<ChatMessage> copyMessageEvents = PublishSubject.create();
 
-    public ChatRecyclerViewAdapter(@Nullable OrderedRealmCollection<ChatMessage> data, boolean autoUpdate, User user) {
+    public ChatRecyclerViewAdapter(@Nullable OrderedRealmCollection<ChatMessage> data, boolean autoUpdate, User user, boolean isTavern) {
         super(data, autoUpdate);
         this.user = user;
+        this.isTavern = isTavern;
         if (user != null) this.uuid = user.getId();
     }
 
@@ -63,7 +65,7 @@ public class ChatRecyclerViewAdapter extends RealmRecyclerViewAdapter<ChatMessag
     public ChatRecyclerViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.tavern_chat_item, parent, false);
-        return new ChatRecyclerViewHolder(view, uuid);
+        return new ChatRecyclerViewHolder(view, uuid, isTavern);
     }
 
     @Override
@@ -108,25 +110,27 @@ public class ChatRecyclerViewAdapter extends RealmRecyclerViewAdapter<ChatMessag
         ImageView btnOptions;
         @BindView(R.id.user_background_layout)
         LinearLayout userBackground;
-        @BindView(R.id.like_background_layout)
-        LinearLayout likeBackground;
         @BindView(R.id.user_label)
         TextView userLabel;
         @BindView(R.id.message_text)
         EmojiTextView messageText;
         @BindView(R.id.ago_label)
         TextView agoLabel;
+        @BindView(R.id.like_background_layout)
+        LinearLayout likeBackground;
         @BindView(R.id.tvLikes)
         TextView tvLikes;
 
         Context context;
         Resources res;
         private String userId;
+        private boolean isTavern;
         private ChatMessage chatMessage;
 
-        ChatRecyclerViewHolder(View itemView, String currentUserId) {
+        ChatRecyclerViewHolder(View itemView, String currentUserId, boolean isTavern) {
             super(itemView);
             this.userId = currentUserId;
+            this.isTavern = isTavern;
 
             ButterKnife.bind(this, itemView);
 
@@ -191,6 +195,7 @@ public class ChatRecyclerViewAdapter extends RealmRecyclerViewAdapter<ChatMessag
         }
 
         private void setLikeProperties() {
+            likeBackground.setVisibility(isTavern ? View.VISIBLE : View.INVISIBLE);
             tvLikes.setText("+" + chatMessage.getLikeCount());
 
             int backgroundColorRes;

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatListFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatListFragment.java
@@ -141,7 +141,7 @@ public class ChatListFragment extends BaseFragment implements SwipeRefreshLayout
             recyclerView.setLayoutManager(layoutManager);
         }
 
-        chatAdapter = new ChatRecyclerViewAdapter(null, true, user);
+        chatAdapter = new ChatRecyclerViewAdapter(null, true, user, true);
         compositeSubscription.add(chatAdapter.getUserLabelClickEvents().subscribe(userId -> FullProfileActivity.open(getContext(), userId), RxErrorHandler.handleEmptyError()));
         compositeSubscription.add(chatAdapter.getDeleteMessageEvents().subscribe(this::showDeleteConfirmationDialog, RxErrorHandler.handleEmptyError()));
         compositeSubscription.add(chatAdapter.getFlatMessageEvents().subscribe(this::showFlagConfirmationDialog, RxErrorHandler.handleEmptyError()));

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/InboxMessageListFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/InboxMessageListFragment.java
@@ -80,7 +80,7 @@ public class InboxMessageListFragment extends BaseMainFragment
         //layoutManager.setStackFromEnd(false);
         recyclerView.setLayoutManager(layoutManager);
 
-        chatAdapter = new ChatRecyclerViewAdapter(null, true, user);
+        chatAdapter = new ChatRecyclerViewAdapter(null, true, user, false);
         chatAdapter.setSendingUser(this.user);
         recyclerView.setAdapter(chatAdapter);
         recyclerView.setItemAnimator(new SafeDefaultItemAnimator());


### PR DESCRIPTION
Fixes #816

This fix hides "like" button in messages, but keeps it in Tavern chats.

Habitica User-ID: 8eea96e0-042c-44f4-b589-e3177f59bcdd
