### PR TITLE
Fix travis setup to accept 26.0.2 build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-26.0.1
+    - build-tools-26.0.2
 
     # The SDK version used to compile your project
     - android-26


### PR DESCRIPTION
Current travis build tools version is not in sync with modules.

my Habitica User-ID: 6a5dcf62-46d7-41f6-b4a5-19b1bc8a3784
