### PR TITLE
used correct serialized name for disabledClasses (#983)

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/Preferences.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/Preferences.kt
@@ -15,6 +15,7 @@ open class Preferences : RealmObject(), AvatarPreferences {
     private var hair: Hair? = null
     var suppressModals: SuppressedModals? = null
     private var costume: Boolean = false
+    @SerializedName("disableClasses")
     var isDisableClasses: Boolean = false
     @SerializedName("sleep")
     var isSleep: Boolean = false


### PR DESCRIPTION
Fixes #983.  Correctly deserialize the `diabledClasses` information.

I'm not too familiar with Realm, let me know if there is anything else that needs to be done since I did add to the model's file

my Habitica User-ID: 09229c96-d005-4f97-b9ca-d8a7d84718b3
