### PR TITLE
Fix stats page buffs

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
@@ -378,7 +378,7 @@ class FullProfileActivity : BaseActivity() {
         val buffs = stats.buffs
 
         addAttributeRow(getString(R.string.profile_allocated), stats.str?.toFloat() ?: 0f, stats._int?.toFloat() ?: 0f, stats.con?.toFloat() ?: 0f, stats.per?.toFloat() ?: 0f, true, false)
-        addAttributeRow(getString(R.string.profile_boosts), buffs?.getStr() ?: 0f, buffs?.get_int() ?: 0f, buffs?.getCon() ?: 0f, buffs?.getPer() ?: 0f, true, false)
+        addAttributeRow(getString(R.string.buffs), buffs?.getStr() ?: 0f, buffs?.get_int() ?: 0f, buffs?.getCon() ?: 0f, buffs?.getPer() ?: 0f, true, false)
 
         // Summary row
         addAttributeRow("", attributeStrSum, attributeIntSum, attributeConSum, attributePerSum, false, true)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/StatsFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/StatsFragment.kt
@@ -220,14 +220,14 @@ class StatsFragment: BaseMainFragment() {
         constitutionStatsView.levelValue = levelStat
         perceptionStatsView.levelValue = levelStat
 
-        totalStrength += currentUser.stats?.buffs?.str?.toInt() ?: 0
-        totalIntelligence += currentUser.stats?.buffs?._int?.toInt() ?: 0
-        totalConstitution += currentUser.stats?.buffs?.con?.toInt() ?: 0
-        totalPerception += currentUser.stats?.buffs?.per?.toInt() ?: 0
-        strengthStatsView.buffValue = currentUser.stats?.buffs?.str?.toInt() ?: 0
-        intelligenceStatsView.buffValue = currentUser.stats?.buffs?._int?.toInt() ?: 0
-        constitutionStatsView.buffValue = currentUser.stats?.buffs?.con?.toInt() ?: 0
-        perceptionStatsView.buffValue = currentUser.stats?.buffs?.per?.toInt() ?: 0
+        totalStrength += currentUser.stats?.buffs?.getStr()?.toInt() ?: 0
+        totalIntelligence += currentUser.stats?.buffs?.get_int()?.toInt() ?: 0
+        totalConstitution += currentUser.stats?.buffs?.getCon()?.toInt() ?: 0
+        totalPerception += currentUser.stats?.buffs?.getPer()?.toInt() ?: 0
+        strengthStatsView.buffValue = currentUser.stats?.buffs?.getStr()?.toInt() ?: 0
+        intelligenceStatsView.buffValue = currentUser.stats?.buffs?.get_int()?.toInt() ?: 0
+        constitutionStatsView.buffValue = currentUser.stats?.buffs?.getCon()?.toInt() ?: 0
+        perceptionStatsView.buffValue = currentUser.stats?.buffs?.getPer()?.toInt() ?: 0
 
         totalStrength += currentUser.stats?.str ?: 0
         totalIntelligence += currentUser.stats?._int ?: 0


### PR DESCRIPTION
Fixes: #1056 

Don't know that much how those proxy objects work, so not sure if accessing those properties straight without calling those getters should work or not, but this fixes the problem. Also changed the "Boosts" text label in the profile view to "Buffs" for consistency.

my Habitica User-ID: fa756acf-9127-4a3c-8dac-8ff627d30073

