### PR TITLE
Fix Gradle build errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.sdk_version = 28
 
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
@@ -28,8 +28,8 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Repro: Clone to a new dir, copy config files (as instructed in README), open in latest Android Studio =>
Gradle sync fails with following errors:
```
Failed to resolve: multidex-instrumentation
Open File


Failed to resolve: play-services-ads
Open File


Failed to resolve: play-services-auth
Open File


Failed to resolve: support-v4
Open File


Failed to resolve: firebase-auth-license
Open File


Failed to resolve: multidex-instrumentation
Open File
```

Gradle build fails with the following error:
```
Could not find play-services-ads.aar (com.google.android.gms:play-services-ads:12.0.1).
Searched in the following locations:
    https://jcenter.bintray.com/com/google/android/gms/play-services-ads/12.0.1/play-services-ads-12.0.1.aar
```

Fixed with solution found here:

https://stackoverflow.com/a/50774794/225075

my Habitica User-ID: fa756acf-9127-4a3c-8dac-8ff627d30073
