### PR TITLE
#1084 There are missing entries in language settings.

### DIFF
--- a/Habitica/res/values/values.xml
+++ b/Habitica/res/values/values.xml
@@ -59,6 +59,7 @@
 
     <string-array name="Language">
         <item>English</item>
+        <item>한국어</item>
         <item>Български</item>
         <item>Deutsch</item>
         <item>British English</item>
@@ -81,6 +82,7 @@
 
     <string-array name="LanguageValues">
         <item>en</item>
+        <item>ko</item>
         <item>bg</item>
         <item>de</item>
         <item>en_GB</item>


### PR DESCRIPTION
Settings-APP SETTINGS tab does not contain 'Korean' Settings tab. If the user wants to change to a different language and then set it back to Korean, there is no way to set it.

I read your comment well. Apart from modifications to the typo, it is not possible to change the language to Korean because the menu tab does not have the 'Korean' tab when using the existing Release version. Therefore, it would be better to add the 'Korean' tab to the menu tab.



my Habitica User-ID:hb-4p3td37tlbp5iiwt8
