### PR TITLE
#1085 Some of the text on the bottom menu is cut out and not visible.

### DIFF
--- a/Habitica/res/values/dimens.xml
+++ b/Habitica/res/values/dimens.xml
@@ -135,7 +135,7 @@
     <dimen name="header_border_spacing">16dp</dimen>
     <dimen name="login_field_width">300dp</dimen>
 
-    <dimen name="bb_height">56dp</dimen>
+    <dimen name="bb_height">65dp</dimen>
     <dimen name="bb_default_elevation">8dp</dimen>
     <dimen name="bb_fake_shadow_height">4dp</dimen>
 </resources>


### PR DESCRIPTION
When language is set to Korean, some of the text corresponding to each menu is not shown in the bottom bar tab of the main menu('일일과제', '해야할일').
So, I adjusted the value of "bb_height".

The images before modifying 'BottomBar' are as follows. As you can see, some of the text at the bottom of the tab menu looks clipped.

![default](https://user-images.githubusercontent.com/33437652/49646725-533ccd00-fa63-11e8-855f-fc5edeaecd68.PNG)

Therefore, I think we can solve the problem by adjusting the height of the 'BottomBar' a little bit as follows.

![default](https://user-images.githubusercontent.com/33437652/49646730-5afc7180-fa63-11e8-800d-f27f102c5587.PNG)

If there's a better solution, I'd like to hear your feedback. Thank you.

my Habitica User-ID:hb-4p3td37tlbp5iiwt8
