### PR TITLE
Update avatar stats widget footer

### DIFF
--- a/Habitica/res/layout/widget_avatar_stats.xml
+++ b/Habitica/res/layout/widget_avatar_stats.xml
@@ -217,7 +217,7 @@
                 android:gravity="center_vertical">
 
             <ImageView
-                android:id="@+id/hourglass_cion"
+                android:id="@+id/hourglass_icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
             <TextView

--- a/Habitica/res/layout/widget_avatar_stats.xml
+++ b/Habitica/res/layout/widget_avatar_stats.xml
@@ -224,6 +224,7 @@
                 android:id="@+id/hourglasses_tv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginRight="8dp"
                 android:textColor="@color/textColorSecondaryDark"
                 style="@style/CurrencyTextView"
                 />
@@ -236,6 +237,7 @@
                     android:id="@+id/gems_tv"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginRight="8dp"
                     android:textColor="@color/textColorSecondaryDark"
                 style="@style/CurrencyTextView"
                     />

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
@@ -115,11 +115,11 @@ public class AvatarStatsWidgetProvider extends BaseWidgetProvider {
             remoteViews.setTextViewText(R.id.gems_tv, String.valueOf((int) (user.getBalance() * 4)));
             int hourGlassCount = user.getHourglassCount();
             if (hourGlassCount == 0) {
-                remoteViews.setViewVisibility(R.id.hourglass_cion, View.GONE);
+                remoteViews.setViewVisibility(R.id.hourglass_icon, View.GONE);
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.GONE);
             } else {
-                remoteViews.setImageViewBitmap(R.id.hourglass_cion, HabiticaIconsHelper.imageOfHourglass());
-                remoteViews.setViewVisibility(R.id.hourglass_cion, View.VISIBLE);
+                remoteViews.setImageViewBitmap(R.id.hourglass_icon, HabiticaIconsHelper.imageOfHourglass());
+                remoteViews.setViewVisibility(R.id.hourglass_icon, View.VISIBLE);
                 remoteViews.setTextViewText(R.id.hourglasses_tv, String.valueOf(hourGlassCount));
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.VISIBLE);
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
@@ -115,11 +115,11 @@ public class AvatarStatsWidgetProvider extends BaseWidgetProvider {
             remoteViews.setTextViewText(R.id.gems_tv, String.valueOf((int) (user.getBalance() * 4)));
             int hourGlassCount = user.getHourglassCount();
             if (hourGlassCount == 0) {
-                remoteViews.setViewVisibility(R.id.hourglasses_cion, View.GONE);
+                remoteViews.setViewVisibility(R.id.hourglass_cion, View.GONE);
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.GONE);
             } else {
                 remoteViews.setImageViewBitmap(R.id.hourglass_cion, HabiticaIconsHelper.imageOfHourglass());
-                remoteViews.setViewVisibility(R.id.hourglasses_cion, View.VISIBLE);
+                remoteViews.setViewVisibility(R.id.hourglass_cion, View.VISIBLE);
                 remoteViews.setTextViewText(R.id.hourglasses_tv, String.valueOf(hourGlassCount));
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.VISIBLE);
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/widget/AvatarStatsWidgetProvider.java
@@ -115,12 +115,14 @@ public class AvatarStatsWidgetProvider extends BaseWidgetProvider {
             remoteViews.setTextViewText(R.id.gems_tv, String.valueOf((int) (user.getBalance() * 4)));
             int hourGlassCount = user.getHourglassCount();
             if (hourGlassCount == 0) {
+                remoteViews.setViewVisibility(R.id.hourglasses_cion, View.GONE);
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.GONE);
             } else {
+                remoteViews.setImageViewBitmap(R.id.hourglass_cion, HabiticaIconsHelper.imageOfHourglass());
+                remoteViews.setViewVisibility(R.id.hourglasses_cion, View.VISIBLE);
                 remoteViews.setTextViewText(R.id.hourglasses_tv, String.valueOf(hourGlassCount));
                 remoteViews.setViewVisibility(R.id.hourglasses_tv, View.VISIBLE);
             }
-            remoteViews.setImageViewBitmap(R.id.hourglass_cion, HabiticaIconsHelper.imageOfHourglass());
             remoteViews.setImageViewBitmap(R.id.gem_icon, HabiticaIconsHelper.imageOfGem());
             remoteViews.setImageViewBitmap(R.id.gold_icon, HabiticaIconsHelper.imageOfGold());
             remoteViews.setTextViewText(R.id.lvl_tv, getContext().getString(R.string.user_level, user.getStats().getLvl()));


### PR DESCRIPTION
For the issue #1120 

Changes:
- Added 8 dp margin between avatar stats widget footer elements (Hourglass, Gem and Gold)
- Made the hourglass icon to appear only if the user has any of them and hide the icon if the user doesn't have any hourglasses.

Requesting feedback on the issue and this pull request. I couldn't get a chance to test this locally, so any help in testing this would be most welcome.

my Habitica User-ID: 67zm52r9pix03ftcp
