### PR TITLE
Remove the ability to tap off RYA

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/yesterdailies/YesterdailyDialog.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/yesterdailies/YesterdailyDialog.kt
@@ -175,6 +175,8 @@ class YesterdailyDialog private constructor(context: Context, private val userRe
 
         private fun showDialog(activity: Activity, userRepository: UserRepository, taskRepository: TaskRepository, tasks: List<Task>) {
             val dialog = YesterdailyDialog(activity, userRepository, taskRepository, tasks)
+            dialog.setCancelable(false)
+            dialog.setCanceledOnTouchOutside(false)
             if (!activity.isFinishing) {
                 dialog.show()
                 isDisplaying = true


### PR DESCRIPTION
Issue #1124

To prevent dialog box from getting dismissed on back key
`dialog.setCancelable(false)`

To prevent dialog box from getting dismissed on outside touch
`dialog.setCanceledOnTouchOutside(false)`

my Habitica User-ID: 50199adc-ca2d-461c-bf9e-5d70ee7283fd

