### PR TITLE
Change key for bundle when passing group id

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/NotificationOpenHandler.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/NotificationOpenHandler.kt
@@ -51,7 +51,7 @@ class NotificationOpenHandler {
             if (groupID.isEmpty()) {
                 return
             }
-            MainNavigationController.navigate(R.id.guildFragment, bundleOf("groupId" to groupID))
+            MainNavigationController.navigate(R.id.guildFragment, bundleOf("groupID" to groupID))
 
         }
 


### PR DESCRIPTION
GuildFragmentArgs uses groupID as key

Fixes #1072



my Habitica User-ID: ajsviado
