### PR TITLE
Message posted to Tavern containing banned words does not disappear

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatListFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatListFragment.kt
@@ -294,11 +294,11 @@ class ChatListFragment : BaseFragment(), SwipeRefreshLayout.OnRefreshListener {
 
     private fun sendChatMessage(chatText: String) {
         groupId.notNull {id ->
-            socialRepository.postGroupChat(id, chatText).subscribe(Consumer {
+            socialRepository.postGroupChat(id, chatText).subscribe({
                 recyclerView?.scrollToPosition(0)
-            }, RxErrorHandler.handleEmptyError())
+            }, { throwable ->
+                chatEditText.setText(chatText)
+            RxErrorHandler.reportError(throwable)})
         }
     }
-
-
 }


### PR DESCRIPTION
Fixes #756 
When a person posts text containing a banned word to the tavern, a warning message appears and the message disappears. Now, the message is restored when the warning appears, so that the user can modify it and remove the banned word.



my Habitica User-ID: Placodermi
