### PR TITLE
Including the option to share a challenge

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.22.1'
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     //App Compatibility and Material Design
+    implementation 'androidx.core:core:1.0.1'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.22.1'
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     //App Compatibility and Material Design
-    implementation 'androidx.core:core:1.0.1'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/Habitica/res/menu/menu_challenge_details.xml
+++ b/Habitica/res/menu/menu_challenge_details.xml
@@ -7,5 +7,6 @@
         android:title="@string/action_edit" />
     <item
         android:id="@+id/action_share"
-        android:title="@string/share" />
+        android:title="@string/share"
+        app:actionProviderClass="android.support.v7.widget.ShareActionProvider"/>
 </menu>

--- a/Habitica/res/menu/menu_challenge_details.xml
+++ b/Habitica/res/menu/menu_challenge_details.xml
@@ -5,4 +5,7 @@
     <item
         android:id="@+id/action_edit"
         android:title="@string/action_edit" />
+    <item
+        android:id="@+id/action_share"
+        android:title="@string/share" />
 </menu>

--- a/Habitica/res/menu/menu_challenge_details.xml
+++ b/Habitica/res/menu/menu_challenge_details.xml
@@ -8,5 +8,5 @@
     <item
         android:id="@+id/action_share"
         android:title="@string/share"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider"/>
+        app:actionProviderClass="androidx.appcompat.widget.ShareActionProvider"/>
 </menu>

--- a/Habitica/res/menu/menu_challenge_details.xml
+++ b/Habitica/res/menu/menu_challenge_details.xml
@@ -7,6 +7,5 @@
         android:title="@string/action_edit" />
     <item
         android:id="@+id/action_share"
-        android:title="@string/share"
-        app:actionProviderClass="androidx.appcompat.widget.ShareActionProvider"/>
+        android:title="@string/share"/>
 </menu>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
@@ -1,9 +1,13 @@
 package com.habitrpg.android.habitica.ui.fragments.social.challenges
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AlertDialog
@@ -13,6 +17,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.habitrpg.android.habitica.BuildConfig
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.components.AppComponent
 import com.habitrpg.android.habitica.data.ChallengeRepository
@@ -151,9 +156,6 @@ class ChallengeDetailFragment: BaseMainFragment() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        if (!isCreator) {
-            return
-        }
         inflater.inflate(R.menu.menu_challenge_details, menu)
         val editMenuItem = menu.findItem(R.id.action_edit)
         editMenuItem?.isVisible = isCreator
@@ -167,6 +169,16 @@ class ChallengeDetailFragment: BaseMainFragment() {
             intent.putExtras(bundle)
             startActivity(intent)
             return true
+        }
+        else if (item.itemId == R.id.action_share) {
+            val clipMan = activity?.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            val challengeUri = Uri.parse("${BuildConfig.BASE_URL}/challenges/$challengeID")
+            val clip = ClipData.newUri(activity?.contentResolver, "challenge uri", challengeUri)
+            clipMan?.primaryClip = clip
+            val act = activity
+            if (act != null) {
+                //showSnackbar(act.floatingMenuWrapper, getString(R.string.challenge_url_copied), HabiticaSnackbar.SnackbarDisplayType.NORMAL)
+            }
         }
 
         return super.onOptionsItemSelected(item)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
@@ -12,11 +12,10 @@ import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AlertDialog
 import android.text.method.LinkMovementMethod
+import android.widget.*
 import android.view.*
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.LinearLayout
-import android.widget.TextView
+import androidx.appcompat.widget.ShareActionProvider
+import androidx.core.view.MenuItemCompat
 import com.habitrpg.android.habitica.BuildConfig
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.components.AppComponent
@@ -69,6 +68,7 @@ class ChallengeDetailFragment: BaseMainFragment() {
     var challengeID: String? = null
     var challenge: Challenge? = null
     var isCreator = false
+    var shareActionProvider: ShareActionProvider? = null
 
     override fun injectFragment(component: AppComponent) {
         component.inject(this)
@@ -159,6 +159,15 @@ class ChallengeDetailFragment: BaseMainFragment() {
         inflater.inflate(R.menu.menu_challenge_details, menu)
         val editMenuItem = menu.findItem(R.id.action_edit)
         editMenuItem?.isVisible = isCreator
+
+        val shareMenuItem = menu.findItem(R.id.action_share)
+        shareActionProvider = MenuItemCompat.getActionProvider(shareMenuItem) as? ShareActionProvider
+        val shareGuildIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, "${BuildConfig.BASE_URL}/challenges/$challengeID")
+            type = "text/plain"
+        }
+        shareActionProvider?.setShareIntent(shareGuildIntent)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -169,16 +178,6 @@ class ChallengeDetailFragment: BaseMainFragment() {
             intent.putExtras(bundle)
             startActivity(intent)
             return true
-        }
-        else if (item.itemId == R.id.action_share) {
-            val clipMan = activity?.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-            val challengeUri = Uri.parse("${BuildConfig.BASE_URL}/challenges/$challengeID")
-            val clip = ClipData.newUri(activity?.contentResolver, "challenge uri", challengeUri)
-            clipMan?.primaryClip = clip
-            val act = activity
-            if (act != null) {
-                //showSnackbar(act.floatingMenuWrapper, getString(R.string.challenge_url_copied), HabiticaSnackbar.SnackbarDisplayType.NORMAL)
-            }
         }
 
         return super.onOptionsItemSelected(item)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
@@ -1,21 +1,15 @@
 package com.habitrpg.android.habitica.ui.fragments.social.challenges
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.net.Uri
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AlertDialog
 import android.text.method.LinkMovementMethod
 import android.widget.*
 import android.view.*
-import androidx.appcompat.widget.ShareActionProvider
-import androidx.core.view.MenuItemCompat
 import com.habitrpg.android.habitica.BuildConfig
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.components.AppComponent

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeDetailFragment.kt
@@ -68,7 +68,6 @@ class ChallengeDetailFragment: BaseMainFragment() {
     var challengeID: String? = null
     var challenge: Challenge? = null
     var isCreator = false
-    var shareActionProvider: ShareActionProvider? = null
 
     override fun injectFragment(component: AppComponent) {
         component.inject(this)
@@ -159,15 +158,6 @@ class ChallengeDetailFragment: BaseMainFragment() {
         inflater.inflate(R.menu.menu_challenge_details, menu)
         val editMenuItem = menu.findItem(R.id.action_edit)
         editMenuItem?.isVisible = isCreator
-
-        val shareMenuItem = menu.findItem(R.id.action_share)
-        shareActionProvider = MenuItemCompat.getActionProvider(shareMenuItem) as? ShareActionProvider
-        val shareGuildIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, "${BuildConfig.BASE_URL}/challenges/$challengeID")
-            type = "text/plain"
-        }
-        shareActionProvider?.setShareIntent(shareGuildIntent)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -178,6 +168,14 @@ class ChallengeDetailFragment: BaseMainFragment() {
             intent.putExtras(bundle)
             startActivity(intent)
             return true
+        }
+        else if (item.itemId == R.id.action_share) {
+            val shareGuildIntent = Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, "${BuildConfig.BASE_URL}/challenges/$challengeID")
+                type = "text/plain"
+            }
+            startActivity(shareGuildIntent)
         }
 
         return super.onOptionsItemSelected(item)


### PR DESCRIPTION
Fixes #1118 

The overflow menu in the Challenge Details screen now includes a Share option, which opens a share sheet with the Challenge URL.

my Habitica User-ID: 55a3cc27-2b92-4901-8313-e194c070bc6e

![image](https://user-images.githubusercontent.com/5496948/57340651-2291ba00-710d-11e9-8299-6cceec39a908.png)
