### PR TITLE
#1122 Show confirmation toast when group invite sent

### DIFF
--- a/Habitica/res/layout/activity_party_invite.xml
+++ b/Habitica/res/layout/activity_party_invite.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -31,3 +36,12 @@
         android:background="@android:color/white" />
 
 </LinearLayout>
+
+<FrameLayout
+android:id="@+id/snackbar_view"
+android:layout_width="match_parent"
+android:layout_height="80dp"
+android:layout_gravity="bottom"
+android:layout_marginBottom="@dimen/spacing_large"
+android:fitsSystemWindows="true" />
+</FrameLayout>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/GroupInviteActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/GroupInviteActivity.kt
@@ -80,9 +80,13 @@ class GroupInviteActivity : BaseActivity() {
 
         if (id == R.id.action_send_invites) {
             setResult(Activity.RESULT_OK, createResultIntent())
-            showSnackbar(snackbarView, "Invite Sent!", HabiticaSnackbar.SnackbarDisplayType.SUCCESS)
             dismissKeyboard()
-            runDelayed(1, TimeUnit.SECONDS, this::finish)
+            if (!fragments[viewPager.currentItem].values.isEmpty()) {
+                showSnackbar(snackbarView, "Invite Sent!", HabiticaSnackbar.SnackbarDisplayType.SUCCESS)
+                runDelayed(1, TimeUnit.SECONDS, this::finish)
+            } else {
+                finish()
+            }
             return true
         }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/GroupInviteActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/GroupInviteActivity.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.widget.Toast
+import android.view.ViewGroup
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentPagerAdapter
@@ -16,6 +16,7 @@ import com.habitrpg.android.habitica.components.AppComponent
 import com.habitrpg.android.habitica.data.SocialRepository
 import com.habitrpg.android.habitica.data.UserRepository
 import com.habitrpg.android.habitica.extensions.notNull
+import com.habitrpg.android.habitica.extensions.runDelayed
 import com.habitrpg.android.habitica.helpers.RxErrorHandler
 import com.habitrpg.android.habitica.models.user.User
 import com.habitrpg.android.habitica.modules.AppModule
@@ -23,8 +24,11 @@ import com.habitrpg.android.habitica.prefs.scanner.IntentIntegrator
 import com.habitrpg.android.habitica.ui.fragments.social.party.PartyInviteFragment
 import com.habitrpg.android.habitica.ui.helpers.bindView
 import com.habitrpg.android.habitica.ui.helpers.dismissKeyboard
+import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar
+import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.Companion.showSnackbar
 import io.reactivex.functions.Consumer
 import java.util.*
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -39,6 +43,7 @@ class GroupInviteActivity : BaseActivity() {
 
     internal val tabLayout: TabLayout by bindView(R.id.tab_layout)
     internal val viewPager: ViewPager by bindView(R.id.viewPager)
+    private val snackbarView: ViewGroup by bindView(R.id.snackbar_view)
 
     internal var fragments: MutableList<PartyInviteFragment> = ArrayList()
     private var userIdToInvite: String? = null
@@ -75,8 +80,9 @@ class GroupInviteActivity : BaseActivity() {
 
         if (id == R.id.action_send_invites) {
             setResult(Activity.RESULT_OK, createResultIntent())
+            showSnackbar(snackbarView, "Invite Sent!", HabiticaSnackbar.SnackbarDisplayType.SUCCESS)
             dismissKeyboard()
-            finish()
+            runDelayed(1, TimeUnit.SECONDS, this::finish)
             return true
         }
 
@@ -151,10 +157,6 @@ class GroupInviteActivity : BaseActivity() {
         if (this.userIdToInvite == null) {
             return
         }
-
-        val toast = Toast.makeText(applicationContext,
-                "Invited: $userIdToInvite", Toast.LENGTH_LONG)
-        toast.show()
 
         val inviteData = HashMap<String, Any>()
         val invites = ArrayList<String>()


### PR DESCRIPTION
Snackbar displays when invite is sent via email or username for membership to a party or guild.
Snackbar is not displayed if the email or username field is empty, but does not do email format verification.

my Habitica User- hb-ey0hcxy7votktic9a
