### PR TITLE
Change color of buff icon to match web and add to main header

### DIFF
--- a/Habitica/res/layout/avatar_with_bars.xml
+++ b/Habitica/res/layout/avatar_with_bars.xml
@@ -78,6 +78,13 @@
                 android:textSize="14sp"
                 tools:text="Lvl 12 Warrior"/>
 
+        <ImageView
+            android:id="@+id/buffImageView"
+            android:layout_width="15dp"
+            android:layout_height="15dp"
+            android:layout_marginStart="8dp"
+            tools:srcCompat="@tools:sample/avatars" />
+
         <View
                 android:layout_width="0dp"
                 android:layout_height="0dp"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.View
+import android.widget.ImageView
 import android.widget.TextView
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.data.UserRepository
@@ -17,6 +18,7 @@ import com.habitrpg.android.habitica.models.user.Stats
 import com.habitrpg.android.habitica.models.user.User
 import com.habitrpg.android.habitica.ui.helpers.bindView
 import com.habitrpg.android.habitica.ui.views.CurrencyViews
+import com.habitrpg.android.habitica.ui.views.HabiticaIcons
 import com.habitrpg.android.habitica.ui.views.HabiticaIconsHelper
 import com.habitrpg.android.habitica.ui.views.ValueBar
 import io.reactivex.disposables.Disposable
@@ -31,6 +33,7 @@ class AvatarWithBarsViewModel(private val context: Context, view: View, userRepo
     private val avatarView: AvatarView by bindView(view, R.id.avatarView)
     private val lvlText: TextView by bindView(view, R.id.lvl_tv)
     private val currencyView: CurrencyViews by bindView(view, R.id.currencyView)
+    private val buffImageView: ImageView by bindView(view, R.id.buffImageView)
 
     private var userObject: Avatar? = null
 
@@ -44,7 +47,7 @@ class AvatarWithBarsViewModel(private val context: Context, view: View, userRepo
         hpBar.setIcon(HabiticaIconsHelper.imageOfHeartLightBg())
         xpBar.setIcon(HabiticaIconsHelper.imageOfExperience())
         mpBar.setIcon(HabiticaIconsHelper.imageOfMagic())
-
+        buffImageView.setImageBitmap(HabiticaIconsHelper.imageOfBuffIcon())
         setHpBarData(0f, 50)
         setXpBarData(0f, 1)
         setMpBarData(0f, 1)
@@ -89,6 +92,10 @@ class AvatarWithBarsViewModel(private val context: Context, view: View, userRepo
         setHpBarData(stats.hp?.toFloat() ?: 0.toFloat(), stats.maxHealth ?: 0)
         setXpBarData(stats.exp?.toFloat() ?: 0.toFloat(), stats.toNextLevel ?: 0)
         setMpBarData(stats.mp?.toFloat() ?: 0.toFloat(), stats.maxMP ?: 0)
+
+        if (!stats.isBuffed) {
+            buffImageView.visibility = View.GONE
+        }
 
         currencyView.gold = stats.gp ?: 0.0
         if (user is User) {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/HabiticaIcons.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/HabiticaIcons.java
@@ -11895,8 +11895,8 @@ public class HabiticaIcons {
         Paint paint = CacheForBuffIcon.paint;
         
         // Local Colors
-        int fillColor18 = Color.argb(255, 154, 98, 255);
-        int fillColor85 = Color.argb(255, 237, 236, 238);
+        int fillColor18 = Color.argb(255, 185, 172, 252);
+        int fillColor85 = Color.argb(255, 37, 29, 60);
         
         // Resize to Target Frame
         canvas.save();


### PR DESCRIPTION
Fixes #996 
* changed icon color to match what was on web
* added buff icon to main header view

<img width="258" alt="Screen Shot 2019-10-05 at 6 40 14 PM" src="https://user-images.githubusercontent.com/5355231/66262103-9957df80-e79f-11e9-9d77-26bcba21776b.png">

Just to show the color change on a different view
![Screen Shot 2019-10-05 at 6 41 35 PM](https://user-images.githubusercontent.com/5355231/66262114-cdcb9b80-e79f-11e9-97bc-1ea52045e762.png)


my Habitica User-ID: 09229c96-d005-4f97-b9ca-d8a7d84718b3
