### PR TITLE
Fixes for todo lists drag and drop

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
@@ -2,7 +2,6 @@ package com.habitrpg.android.habitica.ui.fragments.tasks
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.util.TypedValue
@@ -150,7 +149,6 @@ open class TaskRecyclerViewFragment : BaseFragment(), androidx.swiperefreshlayou
             override fun onSelectedChanged(viewHolder: androidx.recyclerview.widget.RecyclerView.ViewHolder?, actionState: Int) {
                 super.onSelectedChanged(viewHolder, actionState)
                 if (viewHolder != null) {
-                    viewHolder.itemView.setBackgroundColor(Color.LTGRAY)
                     if (fromPosition == null) {
                         fromPosition = viewHolder.adapterPosition
                     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
@@ -91,10 +91,6 @@ open class TaskRecyclerViewFragment : BaseFragment(), androidx.swiperefreshlayou
             else -> null
         }
 
-        if (classType != Task.TYPE_REWARD) {
-            allowReordering()
-        }
-
         recyclerAdapter = adapter as? TaskRecyclerViewAdapter
         recyclerView.adapter = adapter
 
@@ -216,6 +212,11 @@ open class TaskRecyclerViewFragment : BaseFragment(), androidx.swiperefreshlayou
         return androidx.recyclerview.widget.LinearLayoutManager(context)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        mItemTouchCallback = null
+    }
+
     override fun onDestroy() {
         userRepository.close()
         inventoryRepository.close()
@@ -239,6 +240,11 @@ open class TaskRecyclerViewFragment : BaseFragment(), androidx.swiperefreshlayou
         if (recyclerView.adapter == null) {
             this.setInnerAdapter()
         }
+
+        if (classType != Task.TYPE_REWARD) {
+            allowReordering()
+        }
+
         if (this.classType != null) {
             recyclerAdapter?.errorButtonEvents?.subscribe(Consumer {
                 taskRepository.syncErroredTasks().subscribe(Consumer {}, RxErrorHandler.handleEmptyError())

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/tasks/BaseTaskViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/tasks/BaseTaskViewHolder.kt
@@ -23,6 +23,7 @@ abstract class BaseTaskViewHolder constructor(itemView: View, var scoreTaskFunc:
 
 
     var task: Task? = null
+    var movingFromPosition: Int? = null
     var errorButtonClicked: Action? = null
     protected var context: Context
     private val titleTextView: EllipsisTextView by bindView(itemView, R.id.checkedTextView)


### PR DESCRIPTION
Fixes for issue #1079 

1) Drag'n'drop stopped working when you switch between 'Habits' and 'To-Do' tabs.
**Cause:** `allowReordering()` was called only when adapter is null, but when you switch between tabs it isn't
**Solution:** moved `allowReordering()` out of adapter nullability check
2) Item on dailies and todo's fragment are gray for a long time after movement finished
**Cause:** Color was set in bindViewHolder for dailies and todos, but not for habits
**Solution:** Removed color setting (behavior is similar to items on habits now)
3) Fast changes on lists cause items to jump around
**Cause:** Since we are using RealmRecyclerViewAdapter with autoUpdate=true, when we change task position in `clearView()`, it tried to update list visually. Hence there was an attempt to remove animations by using `skipAnimation`. But it just hid animations, while really data wasn't changed, so fast changes caused conflicts.
**Solution:** I saw there was an attempt to use custom listener to prevent such behavior, but it wasn't used in code. I removed hack with `skipAnimation` and implemented more correct approach - by not notifying adapter if movement was already tracked by ItemTouchHelper. It still not perfect, but it looks better than before. 

Also I have proposal is to rewrite drag'n'drop system completely, modifying local tasks repository in `ItemTouchHelper.onMove`, and uploading data to server same as now (after movement is finished; or maybe even write some timed sync system for that). That will eliminate visual inconsistencies much more reliable. 
But I am not sure that that would be correct to fix in this pr. Should I create an issue with this proposal?

my Habitica User-ID: 8eea96e0-042c-44f4-b589-e3177f59bcdd
