### PR TITLE
Rename appropriate sections in Pets & Mounts screen

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -102,6 +102,8 @@ dependencies {
     }
     //Tests
     testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'org.assertj:assertj-core:2.6.0'
     testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
     testImplementation 'org.robolectric:robolectric:3.8'

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -954,4 +954,7 @@
     <string name="unlock_level_short">Level %d</string>
     <string name="not_participating">You are not participating</string>
     <string name="quest_completed">Quest completed!</string>
+
+    <string name="standard"> standard </string>
+    <string name="drop"> drop </string>
 </resources>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -955,6 +955,6 @@
     <string name="not_participating">You are not participating</string>
     <string name="quest_completed">Quest completed!</string>
 
-    <string name="standard"> standard </string>
-    <string name="drop"> drop </string>
+    <string name="standard"> Standard </string>
+    <string name="wacky"> Wacky </string>
 </resources>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/Animal-Extensions.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/Animal-Extensions.kt
@@ -1,7 +1,8 @@
-package com.habitrpg.android.habitica.models.inventory
+package com.habitrpg.android.habitica.extensions
 
 import android.content.Context
 import com.habitrpg.android.habitica.R
+import com.habitrpg.android.habitica.models.inventory.Animal
 
 fun Animal.getTranslatedType(c: Context?): String {
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/Animal-Extensions.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/Animal-Extensions.kt
@@ -5,6 +5,9 @@ import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.models.inventory.Animal
 
 fun Animal.getTranslatedType(c: Context?): String {
+    if (c == null) {
+        return type
+    }
 
     var currType: String = when (type) {
         "drop"    -> c?.getString(R.string.standard).toString()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
@@ -15,8 +15,6 @@ public interface Animal {
 
     void setType(String type);
 
-    String getTranslatedType(Context c);
-
     String getAnimal();
 
     void setAnimal(String animal);

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
@@ -1,5 +1,4 @@
 package com.habitrpg.android.habitica.models.inventory;
-import android.content.Context;
 
 public interface Animal {
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Animal.java
@@ -1,5 +1,5 @@
 package com.habitrpg.android.habitica.models.inventory;
-
+import android.content.Context;
 
 public interface Animal {
 
@@ -14,6 +14,8 @@ public interface Animal {
     String getType();
 
     void setType(String type);
+
+    String getTranslatedType(Context c);
 
     String getAnimal();
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/AnimalExtension.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/AnimalExtension.kt
@@ -4,19 +4,15 @@ import android.content.Context
 import com.habitrpg.android.habitica.R
 
 fun Animal.getTranslatedType(c: Context?): String {
-    var currType = type
 
-    if (currType == "drop") {
-        currType = c?.getString(R.string.standard)
-    }
-    if (currType == "quest") {
-        currType = c?.getString(R.string.quest)
-    }
-    if (currType == "wacky") {
-        currType = c?.getString(R.string.wacky)
-    }
-    if (currType == "special") {
-        currType = c?.getString(R.string.special)
+    var currType: String = when (type) {
+        "drop"    -> c?.getString(R.string.standard).toString()
+        "quest"   -> c?.getString(R.string.quest).toString()
+        "wacky"   -> c?.getString(R.string.wacky).toString()
+        "special" -> c?.getString(R.string.special).toString()
+        else      -> {
+            type
+        }
     }
 
     return currType

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/AnimalExtension.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/AnimalExtension.kt
@@ -1,0 +1,23 @@
+package com.habitrpg.android.habitica.models.inventory
+
+import android.content.Context
+import com.habitrpg.android.habitica.R
+
+fun Animal.getTranslatedType(c: Context?): String {
+    var currType = type
+
+    if (currType == "drop") {
+        currType = c?.getString(R.string.standard)
+    }
+    if (currType == "quest") {
+        currType = c?.getString(R.string.quest)
+    }
+    if (currType == "wacky") {
+        currType = c?.getString(R.string.wacky)
+    }
+    if (currType == "special") {
+        currType = c?.getString(R.string.special)
+    }
+
+    return currType
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
@@ -48,10 +48,18 @@ public class Mount extends RealmObject implements Animal {
     @Override
     public String getTranslatedType(Context c) {
         String currType = type;
-        String translation = c.getString(R.string.drop);
 
-        if (currType.equals(translation)) {
+        if (currType.equals("drop")) {
             currType = c.getString(R.string.standard);
+        }
+        if (currType.equals("quest")) {
+            currType = c.getString(R.string.quest);
+        }
+        if (currType.equals("wacky")) {
+            currType = c.getString(R.string.wacky);
+        }
+        if (currType.equals("special")) {
+            currType = c.getString(R.string.special);
         }
 
         return currType;

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
@@ -1,8 +1,5 @@
 package com.habitrpg.android.habitica.models.inventory;
 
-import android.content.Context;
-import com.habitrpg.android.habitica.R;
-
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
@@ -45,26 +45,6 @@ public class Mount extends RealmObject implements Animal {
         this.type = type;
     }
 
-    @Override
-    public String getTranslatedType(Context c) {
-        String currType = type;
-
-        if (currType.equals("drop")) {
-            currType = c.getString(R.string.standard);
-        }
-        if (currType.equals("quest")) {
-            currType = c.getString(R.string.quest);
-        }
-        if (currType.equals("wacky")) {
-            currType = c.getString(R.string.wacky);
-        }
-        if (currType.equals("special")) {
-            currType = c.getString(R.string.special);
-        }
-
-        return currType;
-    }
-
     public String getAnimal() {
         if (animal == null) {
             return key.split("-")[0];

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Mount.java
@@ -1,6 +1,7 @@
 package com.habitrpg.android.habitica.models.inventory;
 
-import androidx.annotation.Nullable;
+import android.content.Context;
+import com.habitrpg.android.habitica.R;
 
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
@@ -42,6 +43,18 @@ public class Mount extends RealmObject implements Animal {
     @Override
     public void setType(String type) {
         this.type = type;
+    }
+
+    @Override
+    public String getTranslatedType(Context c) {
+        String currType = type;
+        String translation = c.getString(R.string.drop);
+
+        if (currType.equals(translation)) {
+            currType = c.getString(R.string.standard);
+        }
+
+        return currType;
     }
 
     public String getAnimal() {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
@@ -45,10 +45,18 @@ public class Pet extends RealmObject implements Animal{
     @Override
     public String getTranslatedType(Context c) {
         String currType = type;
-        String translation = c.getString(R.string.drop);
 
-        if (currType.equals(translation)) {
+        if (currType.equals("drop")) {
             currType = c.getString(R.string.standard);
+        }
+        if (currType.equals("quest")) {
+            currType = c.getString(R.string.quest);
+        }
+        if (currType.equals("wacky")) {
+            currType = c.getString(R.string.wacky);
+        }
+        if (currType.equals("special")) {
+            currType = c.getString(R.string.special);
         }
 
         return currType;

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
@@ -1,6 +1,9 @@
 package com.habitrpg.android.habitica.models.inventory;
 
 
+import android.content.Context;
+import com.habitrpg.android.habitica.R;
+
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;
@@ -28,6 +31,7 @@ public class Pet extends RealmObject implements Animal{
         return text;
     }
 
+
     @Override
     public void setText(String text) {
         this.text = text;
@@ -36,6 +40,18 @@ public class Pet extends RealmObject implements Animal{
     @Override
     public String getType() {
         return type;
+    }
+
+    @Override
+    public String getTranslatedType(Context c) {
+        String currType = type;
+        String translation = c.getString(R.string.drop);
+
+        if (currType.equals(translation)) {
+            currType = c.getString(R.string.standard);
+        }
+
+        return currType;
     }
 
     @Override

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
@@ -1,9 +1,5 @@
 package com.habitrpg.android.habitica.models.inventory;
 
-
-import android.content.Context;
-import com.habitrpg.android.habitica.R;
-
 import io.realm.RealmObject;
 import io.realm.annotations.Ignore;
 import io.realm.annotations.PrimaryKey;

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/inventory/Pet.java
@@ -43,26 +43,6 @@ public class Pet extends RealmObject implements Animal{
     }
 
     @Override
-    public String getTranslatedType(Context c) {
-        String currType = type;
-
-        if (currType.equals("drop")) {
-            currType = c.getString(R.string.standard);
-        }
-        if (currType.equals("quest")) {
-            currType = c.getString(R.string.quest);
-        }
-        if (currType.equals("wacky")) {
-            currType = c.getString(R.string.wacky);
-        }
-        if (currType.equals("special")) {
-            currType = c.getString(R.string.special);
-        }
-
-        return currType;
-    }
-
-    @Override
     public void setType(String type) {
         this.type = type;
     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
@@ -157,7 +157,7 @@ class StableRecyclerFragment : BaseFragment() {
                 if (items.size > 0 && items[items.size - 1].javaClass == String::class.java) {
                     items.removeAt(items.size - 1)
                 }
-                items.add(animal.type)
+                items.add(animal.getTranslatedType(context))
                 lastSectionTitle = animal.type
             }
             when (itemType) {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
@@ -11,6 +11,7 @@ import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.extensions.inflate
 import com.habitrpg.android.habitica.helpers.RxErrorHandler
 import com.habitrpg.android.habitica.models.inventory.Animal
+import com.habitrpg.android.habitica.models.inventory.getTranslatedType
 import com.habitrpg.android.habitica.models.user.OwnedMount
 import com.habitrpg.android.habitica.models.user.OwnedObject
 import com.habitrpg.android.habitica.models.user.OwnedPet

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/StableRecyclerFragment.kt
@@ -8,10 +8,10 @@ import android.widget.TextView
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.components.UserComponent
 import com.habitrpg.android.habitica.data.InventoryRepository
+import com.habitrpg.android.habitica.extensions.getTranslatedType
 import com.habitrpg.android.habitica.extensions.inflate
 import com.habitrpg.android.habitica.helpers.RxErrorHandler
 import com.habitrpg.android.habitica.models.inventory.Animal
-import com.habitrpg.android.habitica.models.inventory.getTranslatedType
 import com.habitrpg.android.habitica.models.user.OwnedMount
 import com.habitrpg.android.habitica.models.user.OwnedObject
 import com.habitrpg.android.habitica.models.user.OwnedPet

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/models/inventory/MountTest.kt
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/models/inventory/MountTest.kt
@@ -1,0 +1,38 @@
+package com.habitrpg.android.habitica.models.inventory;
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.habitrpg.android.habitica.R
+import com.habitrpg.android.habitica.extensions.getTranslatedType
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+private const val FAKE_STANDARD = "Standard"
+private const val FAKE_PREMIUM = "premium"
+
+class MountTest {
+    @Mock
+    private var mockContext: Context = mock(Context::class.java)
+    private var mount: Mount = Mount()
+
+    @Test
+    fun testGetTranslatedStringReturnsStandard() {
+        mount.type = "drop"
+        `when`(mockContext.getString(R.string.standard)).thenReturn(FAKE_STANDARD)
+
+        val result: String = mount.getTranslatedType(mockContext)
+
+        assertThat(result).isEqualTo(FAKE_STANDARD)
+    }
+
+    @Test
+    fun testGetTranslatedStringReturnsPremiumWhenContextIsNull() {
+        mount.type = "premium"
+
+        val result: String = mount.getTranslatedType(null)
+
+        assertThat(result).isEqualTo(FAKE_PREMIUM)
+    }
+}

--- a/Habitica/src/test/java/com/habitrpg/android/habitica/models/inventory/PetTest.kt
+++ b/Habitica/src/test/java/com/habitrpg/android/habitica/models/inventory/PetTest.kt
@@ -1,0 +1,38 @@
+package com.habitrpg.android.habitica.models.inventory;
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.habitrpg.android.habitica.R
+import com.habitrpg.android.habitica.extensions.getTranslatedType
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+private const val FAKE_STANDARD = "Standard"
+private const val FAKE_PREMIUM = "premium"
+
+class PetTest {
+    @Mock
+    private var mockContext: Context = mock(Context::class.java)
+    private var pet: Pet = Pet()
+
+    @Test
+    fun testGetTranslatedStringReturnsStandard() {
+        pet.type = "drop"
+        `when`(mockContext.getString(R.string.standard)).thenReturn(FAKE_STANDARD)
+
+        val result: String = pet.getTranslatedType(mockContext)
+
+        assertThat(result).isEqualTo(FAKE_STANDARD)
+    }
+
+    @Test
+    fun testGetTranslatedStringReturnsPremiumWhenContextIsNull() {
+        pet.type = "premium"
+
+        val result: String = pet.getTranslatedType(null)
+
+        assertThat(result).isEqualTo(FAKE_PREMIUM)
+    }
+}


### PR DESCRIPTION
Functionality: renamed the "drop" section in pets and mounts so that it now says "standard"

Did this by adding a getTranslatedType method in Pet and Mount classes that override the the parent method in Animal class. 

![Screenshot_20200228-141506](https://user-images.githubusercontent.com/22849233/75580440-c4381e00-5a35-11ea-955b-04b7105bf19e.png)