### PR TITLE
fix crash happening in pets & mounts

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
@@ -9,12 +9,14 @@ import android.widget.Button
 import android.widget.Spinner
 import android.widget.TextView
 import com.habitrpg.android.habitica.R
+import com.habitrpg.android.habitica.databinding.CustomizationSectionHeaderBinding
 import com.habitrpg.android.habitica.ui.helpers.bindView
 
 class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
+    private val binding = CustomizationSectionHeaderBinding.bind(itemView)
     private val label: TextView by bindView(itemView, R.id.label)
-    private val purchaseSetButton: Button? by bindView(itemView, R.id.purchaseSetButton)
+//    private val purchaseSetButton: Button? by bindView(itemView, R.id.purchaseSetButton)
     private val selectionSpinner: Spinner? by bindView(itemView, R.id.classSelectionSpinner)
     internal val notesView: TextView? by bindView(itemView, R.id.headerNotesView)
     var context: Context = itemView.context
@@ -22,7 +24,7 @@ class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     var spinnerSelectionChanged: (() -> Unit)? = null
 
     init {
-        this.purchaseSetButton?.visibility = View.GONE
+        binding.purchaseSetButton.visibility = View.GONE
         selectionSpinner?.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 spinnerSelectionChanged?.invoke()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
@@ -16,7 +16,6 @@ class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
     private val binding = CustomizationSectionHeaderBinding.bind(itemView)
     private val label: TextView by bindView(itemView, R.id.label)
-//    private val purchaseSetButton: Button? by bindView(itemView, R.id.purchaseSetButton)
     private val selectionSpinner: Spinner? by bindView(itemView, R.id.classSelectionSpinner)
     internal val notesView: TextView? by bindView(itemView, R.id.headerNotesView)
     var context: Context = itemView.context


### PR DESCRIPTION
what was happening: 
Pets & mounts was crashing due to the fact that the purchase button now needs to be set to `gone` with a binding variable. This is done in `CustomizationRecyclerViewAdapter`, so I made it consistent in `SectionViewHolder`

