### PR TITLE
fix bindings for SectionViewHolders for shop and pets&mounts

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
@@ -3,18 +3,13 @@ package com.habitrpg.android.habitica.ui.viewHolders
 import android.content.Context
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
-import android.widget.Button
-import android.widget.Spinner
-import android.widget.TextView
+import android.widget.*
 import com.habitrpg.android.habitica.R
-import com.habitrpg.android.habitica.databinding.CustomizationSectionHeaderBinding
 import com.habitrpg.android.habitica.ui.helpers.bindView
 
 class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
-    private val binding = CustomizationSectionHeaderBinding.bind(itemView)
+    private val purchaseSetButton: LinearLayout? by bindView(itemView, R.id.purchaseSetButton)
     private val label: TextView by bindView(itemView, R.id.label)
     private val selectionSpinner: Spinner? by bindView(itemView, R.id.classSelectionSpinner)
     internal val notesView: TextView? by bindView(itemView, R.id.headerNotesView)
@@ -23,7 +18,7 @@ class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     var spinnerSelectionChanged: (() -> Unit)? = null
 
     init {
-        binding.purchaseSetButton.visibility = View.GONE
+        this.purchaseSetButton?.visibility = View.GONE
         selectionSpinner?.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 spinnerSelectionChanged?.invoke()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/SectionViewHolder.kt
@@ -3,7 +3,11 @@ package com.habitrpg.android.habitica.ui.viewHolders
 import android.content.Context
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
-import android.widget.*
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.LinearLayout
+import android.widget.Spinner
+import android.widget.TextView
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.ui.helpers.bindView
 


### PR DESCRIPTION
This PR is revisiting the crash happening in Pets and Mounts. That change had retroactively made shops crash because of the inconsistent IDs. I fixed it so that now both screens are now working fine. I also went and checked to see where else was using the header, and it works well.
