### PR TITLE
Changing "home" menu button to be a back press for TaskFormActivity, fixes #1292

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.kt
@@ -224,6 +224,10 @@ class TaskFormActivity : BaseActivity() {
         when (item?.itemId) {
             R.id.action_save -> saveTask()
             R.id.action_delete -> deleteTask()
+            android.R.id.home -> {
+                onBackPressed()
+                return true
+            }
         }
         return super.onOptionsItemSelected(item)
     }


### PR DESCRIPTION
Whenever the TaskFormActivity was launched from the TasksFragment, clicking the "home" back arrow button in the menu caused the TasksFragment to be recreated, due to the default Android behavior since setDisplayHomeUpAsEnabled is true for the actionBar.  This means that whenever the user clicks the home button from the TaskFormActivity, they go back to the TasksFragment, but the task tab is always set to "Habits", instead of the tab they were on before launching the activity.  However, whenever the user clicks "Save" or "Delete" from the TaskFormActivity, the TasksFragment is simply resumed and retains its previous tab state.

I've overwritten the home menu button on the TaskFormActivity to be a back press instead of a "home" press.  This allows the current tab of the TasksFragment to remain on the task type that it was before the user launched the TaskFormActivity.


my Habitica User-ID: 04ec9b30-1464-41f5-af67-fb2482f108a0
