### PR TITLE
Stop re-requesting google auth permissions right after user denied them

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/LoginActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/LoginActivity.kt
@@ -294,7 +294,11 @@ class LoginActivity : BaseActivity(), Consumer<UserAuthResponse> {
             }
         }
         if (requestCode == REQUEST_CODE_RECOVER_FROM_PLAY_SERVICES_ERROR) {
-            handleGoogleLoginResult()
+            // RESULT_CANCELED occurs when user denies requested permissions. In this case we don't
+            // want to immediately ask them to accept permissions again. See Issue #1290 on github.
+            if (resultCode != Activity.RESULT_CANCELED) {
+                handleGoogleLoginResult()
+            }
         }
 
         if (requestCode == FacebookSdk.getCallbackRequestCodeOffset()) {


### PR DESCRIPTION
- Fixes #1290 

- When the user tried to register/sign in without having granted permissions, we get a UserRecoverableAuthException when calling GoogleAuthUtil.getToken, and we (correctly) used the intent on the exception to prompt them to grant permissions.

- HOWEVER, if the user then *denies* permission on that activity, the result code we receive back is RESULT_CANCELLED, (instead of RESULT_OK if they Allow), but in both cases we would still attempt to get a token and prompt for permission again if it failed.

- With this fix we only attempt to get a token again if we *don't get a RESULT_CANCELLED from the permission activity*. 

- This prevents the infinite looping if user doesn't want to grant permissions on that account - whereas before, they had to force-kill the app to choose a different auth method.

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14


