### PR TITLE
Talkback improvements for main stats panel

### DIFF
--- a/Habitica/res/layout/value_bar.xml
+++ b/Habitica/res/layout/value_bar.xml
@@ -15,7 +15,7 @@
             android:layout_alignTop="@+id/progressBar"
             android:layout_marginEnd="@dimen/bar_icon_padding"
             android:layout_marginRight="@dimen/bar_icon_padding"
-            android:contentDescription="Bar Icon"
+            android:contentDescription="@null"
             android:scaleType="center"
             android:visibility="gone"/>
 

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -293,6 +293,7 @@
     <string name="empty_items">You don\'t have any %s</string>
     <string name="user_level">Lvl %d</string>
     <string name="user_level_with_class">Lvl %1$d %2$s</string>
+    <string name="user_level_with_class_unabbreviated">Level %1$d %2$s</string>
     <string name="warrior">Warrior</string>
     <string name="rogue">Rogue</string>
     <string name="mage">Mage</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -953,7 +953,7 @@
     <string name="unlock_previous">Unlock by finishing Quest %d</string>
     <string name="unlock_level">Unlock by reaching level %d</string>
     <string name="unlock_previous_short">Finish Quest %d</string>
-    <string name="unlock_level_short">Level %d</string>
+    <string name="level_unabbreviated">Level %d</string>
     <string name="not_participating">You are not participating</string>
     <string name="quest_completed">Quest completed!</string>
     <string name="using_habitica">Using Habitica</string>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/shops/ShopItem.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/shops/ShopItem.kt
@@ -101,7 +101,7 @@ open class ShopItem : RealmObject() {
                 }
             }
             level != null -> {
-                context.getString(R.string.unlock_level_short, level ?: 0)
+                context.getString(R.string.level_unabbreviated, level ?: 0)
             }
             else -> null
         }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.View
+import android.widget.TextView
 import androidx.core.os.bundleOf
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.data.UserRepository
@@ -63,19 +64,9 @@ class AvatarWithBarsViewModel(private val context: Context, private val binding:
         binding.mpBar.visibility = if (stats.habitClass == null || stats.lvl ?: 0 < 10 || user.preferences?.disableClasses == true) View.GONE else View.VISIBLE
 
         if (!user.hasClass()) {
-            binding.lvlTv.text = context.getString(R.string.user_level, stats.lvl)
-            binding.lvlTv.setCompoundDrawables(null, null, null, null)
+            setUserLevel(context, binding.lvlTv, stats.lvl)
         } else {
-            binding.lvlTv.text = context.getString(R.string.user_level_with_class, stats.lvl, userClass.substring(0, 1).toUpperCase(Locale.getDefault()) + userClass.substring(1))
-            var drawable: Drawable? = null
-            when (stats.habitClass) {
-                Stats.WARRIOR -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfWarriorDarkBg())
-                Stats.ROGUE -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfRogueDarkBg())
-                Stats.MAGE -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfMageDarkBg())
-                Stats.HEALER -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfHealerDarkBg())
-            }
-            drawable?.setBounds(0, 0, drawable.minimumWidth, drawable.minimumHeight)
-            binding.lvlTv.setCompoundDrawables(drawable, null, null, null)
+            setUserLevelWithClass(context, binding.lvlTv, stats.lvl, capitalize(userClass), stats.habitClass)
         }
 
         setHpBarData(stats.hp?.toFloat() ?: 0.toFloat(), stats.maxHealth ?: 0)
@@ -144,5 +135,26 @@ class AvatarWithBarsViewModel(private val context: Context, private val binding:
             val hp = stats.hp?.let { HealthFormatter.format(it) } ?: 0.0
             valueBar.set(hp, maxHP.toDouble())
         }
+
+        private fun setUserLevel(context: Context, textView: TextView, level: Int?) {
+            textView.text = context.getString(R.string.user_level, level)
+            textView.setCompoundDrawables(null, null, null, null)
+        }
+
+        private fun setUserLevelWithClass(context: Context, textView: TextView, level: Int?, userClassString: String, habitClass: String?) {
+            textView.text = context.getString(R.string.user_level_with_class, level, userClassString)
+            var drawable: Drawable? = null
+            when (habitClass) {
+                Stats.WARRIOR -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfWarriorDarkBg())
+                Stats.ROGUE -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfRogueDarkBg())
+                Stats.MAGE -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfMageDarkBg())
+                Stats.HEALER -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfHealerDarkBg())
+            }
+            drawable?.setBounds(0, 0, drawable.minimumWidth, drawable.minimumHeight)
+            textView.setCompoundDrawables(drawable, null, null, null)
+        }
+
+        private fun capitalize(s: String) =
+                s.substring(0, 1).toUpperCase(Locale.getDefault()) + s.substring(1)
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.kt
@@ -138,11 +138,13 @@ class AvatarWithBarsViewModel(private val context: Context, private val binding:
 
         private fun setUserLevel(context: Context, textView: TextView, level: Int?) {
             textView.text = context.getString(R.string.user_level, level)
+            textView.contentDescription = context.getString(R.string.level_unabbreviated, level)
             textView.setCompoundDrawables(null, null, null, null)
         }
 
         private fun setUserLevelWithClass(context: Context, textView: TextView, level: Int?, userClassString: String, habitClass: String?) {
             textView.text = context.getString(R.string.user_level_with_class, level, userClassString)
+            textView.contentDescription = context.getString(R.string.user_level_with_class_unabbreviated, level, userClassString)
             var drawable: Drawable? = null
             when (habitClass) {
                 Stats.WARRIOR -> drawable = BitmapDrawable(context.resources, HabiticaIconsHelper.imageOfWarriorDarkBg())


### PR DESCRIPTION
First set of improvements towards making the whole app work well with Talkback - issue #180

I noticed that when the stats panel was focused with Talkback enabled, it read out "Bar icon forty-two fiftieths health bar icon seventeen seventy-fifths experience 'L' 'V' 'L' three".

With these changes, it now reads out "Forty-two fiftieths health, seventeen seventy-fifths experience, level three'. (It might be better if it read out '42 out of 50' instead of '42 50ths' but that would require a bigger change).

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14
