### PR TITLE
Further Talkback improvements for main activity

### DIFF
--- a/Habitica/res/layout/avatar_with_bars.xml
+++ b/Habitica/res/layout/avatar_with_bars.xml
@@ -26,6 +26,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="16dp"
                 android:layout_marginRight="16dp"
+                android:contentDescription="@string/sidebar_avatar"
                 app:showBackground="true"
                 app:showMount="true"
                 app:showPet="true"/>

--- a/Habitica/res/layout/habit_item_card.xml
+++ b/Habitica/res/layout/habit_item_card.xml
@@ -38,7 +38,8 @@
                 style="@style/HabitButton"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="@drawable/selection_highlight" />
+                android:background="@drawable/selection_highlight"
+                android:contentDescription="@string/positive_habit_form" />
         </FrameLayout>
 
         <LinearLayout
@@ -184,7 +185,8 @@
                 style="@style/HabitButton"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="@drawable/selection_highlight" />
+                android:background="@drawable/selection_highlight"
+                android:contentDescription="@string/negative_habit_form" />
         </FrameLayout>
     </LinearLayout>
 

--- a/Habitica/res/layout/main_navigation_view.xml
+++ b/Habitica/res/layout/main_navigation_view.xml
@@ -12,8 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_alignTop="@id/item_wrapper"
-        android:clickable="true">
+        android:layout_alignTop="@id/item_wrapper">
         <View
             android:layout_width="0dp"
             android:layout_weight="1"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/CurrencyView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/CurrencyView.kt
@@ -20,9 +20,11 @@ class CurrencyView : androidx.appcompat.widget.AppCompatTextView {
     var currency: String? = null
         set(currency) {
             field = currency
+            setCurrencyContentDescriptionFromCurrency(currency)
             configureCurrency()
             updateVisibility()
         }
+    private var currencyContentDescription: String? = null
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         val attributes = context.theme?.obtainStyledAttributes(
@@ -40,7 +42,17 @@ class CurrencyView : androidx.appcompat.widget.AppCompatTextView {
     constructor(context: Context, currency: String, lightbackground: Boolean) : super(context) {
         this.lightBackground = lightbackground
         this.currency = currency
+        setCurrencyContentDescriptionFromCurrency(currency)
         visibility = GONE
+    }
+
+    private fun setCurrencyContentDescriptionFromCurrency(currency: String?) {
+        when (currency) {
+            "gold" -> this.currencyContentDescription = context.getString(R.string.gold_plural)
+            "gems" -> this.currencyContentDescription = context.getString(R.string.gems)
+            "hourglasses" -> this.currencyContentDescription = context.getString(R.string.mystic_hourglasses)
+            else -> this.currencyContentDescription = ""
+        }
     }
 
     private fun configureCurrency() {
@@ -87,7 +99,9 @@ class CurrencyView : androidx.appcompat.widget.AppCompatTextView {
     var value = 0.0
     set(value) {
         field = value
-        text = NumberAbbreviator.abbreviate(context, value)
+        val abbreviatedValue = NumberAbbreviator.abbreviate(context, value)
+        text = abbreviatedValue
+        contentDescription = "$abbreviatedValue $currencyContentDescription"
         updateVisibility()
     }
 


### PR DESCRIPTION
Second set of improvements towards making the whole app work well with Talkback - issue #180

I noticed that when using Talkback there were a number of additional issues in the main tasks activity (besides the ones addressed in #1308).

- Avatar icon was focusable & clickable but had no content description
  - Fixed by giving it a content description, reusing the sidebar 'Avatar' string

- Plus and minus buttons were just read out as "Button"
  - Fixed by giving them content descriptions, reusing the 'Positive' and 'Negative' strings.

- Only the currency values were read out, giving no context as to what currency they referred to (eg "714, 0"
  - Fixed by adding currency string to the content description of these TextViews - so now it reads out e.g. "714 Gold, 0 Gems"

- There was a background view set to be clickable behind the bottom navigation icons, for no apparent reason, so it was focused by Talkback when cycling through, although clicking it did nothing.
  - Fixed by making it not clickable.

- I split the above changes into separate commits for ease of review.

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14
