### PR TITLE
Talkback improvements for New Habit screen

### DIFF
--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="negative_habit_form">Negative</string>
     <string name="on">On</string>
     <string name="off">Off</string>
+    <string name="selected">Selected</string>
+    <string name="not_selected">Not selected</string>
     <string name="checklist">Checklist</string>
     <string name="reminders">Reminders</string>
 

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="start_date">Start Date</string>
     <string name="positive_habit_form">Positive</string>
     <string name="negative_habit_form">Negative</string>
+    <string name="on">On</string>
+    <string name="off">Off</string>
     <string name="checklist">Checklist</string>
     <string name="reminders">Reminders</string>
 

--- a/Habitica/res/values/styles.xml
+++ b/Habitica/res/values/styles.xml
@@ -636,6 +636,7 @@
         <item name="android:textColor">@color/gray_10</item>
         <item name="android:layout_marginTop">@dimen/spacing_large</item>
         <item name="android:layout_marginBottom">@dimen/spacing_medium</item>
+        <item name="android:accessibilityHeading">true</item>
     </style>
 
     <style name="TaskFormToggle">

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitResetStreakButtons.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitResetStreakButtons.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -22,7 +23,11 @@ class HabitResetStreakButtons @JvmOverloads constructor(
         field = value
         removeAllViews()
         addAllButtons()
+        selectedButton.sendAccessibilityEvent(
+                AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
     }
+
+    private lateinit var selectedButton: TextView
 
     init {
         addAllButtons()
@@ -43,14 +48,22 @@ class HabitResetStreakButtons @JvmOverloads constructor(
             button.gravity = Gravity.CENTER
             button.layoutParams = layoutParams
             addView(button)
+            if (resetOption == selectedResetOption) {
+                selectedButton = button;
+            }
         }
     }
 
     private fun createButton(resetOption: HabitResetOption): TextView {
+        val isActive = selectedResetOption == resetOption
+
         val button = TextView(context)
-        button.text = context.getString(resetOption.nameRes)
+        val buttonText = context.getString(resetOption.nameRes)
+        button.text = buttonText
+        button.contentDescription = toContentDescription(buttonText, isActive)
         button.background = ContextCompat.getDrawable(context, R.drawable.layout_rounded_bg_white)
-        if (selectedResetOption == resetOption) {
+
+        if (isActive) {
             button.background.setTint(tintColor)
             button.setTextColor(ContextCompat.getColor(context, R.color.white))
         } else {
@@ -61,5 +74,12 @@ class HabitResetStreakButtons @JvmOverloads constructor(
             selectedResetOption = resetOption
         }
         return button
+    }
+
+    private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {
+        val statusString = if (isActive) {
+            context.getString(R.string.selected)
+        } else context.getString(R.string.not_selected)
+        return "$buttonText, $statusString"
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitScoringButtonsView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitScoringButtonsView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -18,7 +19,7 @@ class HabitScoringButtonsView @JvmOverloads constructor(
         context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
-    private val positiveVew: ViewGroup by bindView(R.id.positive_view)
+    private val positiveView: ViewGroup by bindView(R.id.positive_view)
     private val negativeView: ViewGroup by bindView(R.id.negative_view)
     private val positiveImageView: ImageView by bindView(R.id.positive_image_view)
     private val negativeImageView: ImageView by bindView(R.id.negative_image_view)
@@ -34,8 +35,10 @@ class HabitScoringButtonsView @JvmOverloads constructor(
             positiveImageView.setImageDrawable(HabiticaIconsHelper.imageOfHabitControlPlus(tintColor, value).asDrawable(resources))
             if (value) {
                 positiveTextView.setTextColor(tintColor)
+                positiveView.contentDescription = toContentDescription(R.string.positive_habit_form, R.string.on)
             } else {
                 positiveTextView.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
+                positiveView.contentDescription = toContentDescription(R.string.positive_habit_form, R.string.off)
             }
         }
 
@@ -45,20 +48,28 @@ class HabitScoringButtonsView @JvmOverloads constructor(
             negativeImageView.setImageDrawable(HabiticaIconsHelper.imageOfHabitControlMinus(tintColor, value).asDrawable(resources))
             if (value) {
                 negativeTextView.setTextColor(tintColor)
+                negativeView.contentDescription = toContentDescription(R.string.negative_habit_form, R.string.on)
             } else {
                 negativeTextView.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
+                negativeView.contentDescription = toContentDescription(R.string.negative_habit_form, R.string.off)
             }
         }
+
+    private fun toContentDescription(descriptionStringId: Int, statusStringId: Int): String {
+        return context.getString(descriptionStringId) + ", " + context.getString(statusStringId)
+    }
 
     init {
         View.inflate(context, R.layout.task_form_habit_scoring, this)
         gravity = Gravity.CENTER
 
-        positiveVew.setOnClickListener {
+        positiveView.setOnClickListener {
             isPositive = !isPositive
+            sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
         }
         negativeView.setOnClickListener {
             isNegative = !isNegative
+            sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION);
         }
 
         isPositive = true

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskDifficultyButtons.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskDifficultyButtons.kt
@@ -3,6 +3,7 @@ package com.habitrpg.android.habitica.ui.views.tasks.form
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Space
@@ -24,7 +25,9 @@ class TaskDifficultyButtons @JvmOverloads constructor(
         field = value
         removeAllViews()
         addAllButtons()
+        selectedButton.sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
     }
+    private lateinit var selectedButton: View
 
     init {
         addAllButtons()
@@ -41,6 +44,9 @@ class TaskDifficultyButtons @JvmOverloads constructor(
                 layoutParams.weight = 1f
                 space.layoutParams = layoutParams
                 addView(space)
+            }
+            if (difficulty.value == selectedDifficulty) {
+                selectedButton = button;
             }
         }
     }
@@ -59,10 +65,21 @@ class TaskDifficultyButtons @JvmOverloads constructor(
         }
         val drawable = HabiticaIconsHelper.imageOfTaskDifficultyStars(difficultyColor, difficulty.value, true).asDrawable(resources)
         view.findViewById<ImageView>(R.id.image_view).setImageDrawable(drawable)
-        view.findViewById<TextView>(R.id.text_view).text = context.getText(difficulty.nameRes)
+
+        val buttonText = context.getText(difficulty.nameRes)
+        view.findViewById<TextView>(R.id.text_view).text = buttonText
+        view.contentDescription = toContentDescription(buttonText, isActive)
+
         view.setOnClickListener {
             selectedDifficulty = difficulty.value
         }
         return view
+    }
+
+    private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {
+        val statusString = if (isActive) {
+            context.getString(R.string.selected)
+        } else context.getString(R.string.not_selected)
+        return "$buttonText, $statusString"
     }
 }


### PR DESCRIPTION
Third set of improvements towards making the whole app work well with Talkback - issue #180

- Previously when Talkback was enabled, it would read out all the button labels, but not whether they were currently selected - this was only represented visually by the colour of the buttons.

- Now, Talkback also reads out the current state (on/off, selected/not selected) of the following buttons:
  - Positive / negative habit buttons
  - Task difficulty buttons
  - Reset streak buttons

- This involved some code duplication, especially between the task difficulty buttons & reset streak buttons code. However, the logic being duplicated is fairly simple, so I think this is acceptable for now (especially given the classes already contain a fair amount of duplication.. but perhaps a larger refactor to eliminate this is due in future?).

- I also added `android:accessibilityHeading="true"` to the style of all headings in activity_task_view.xml - as advised at https://developer.android.com/guide/topics/ui/accessibility/principles#headings_within_text - so these are now read out as headings by Talkback.

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14