### PR TITLE
Talkback improvements for New Habit and New Daily screens

### DIFF
--- a/Habitica/res/layout/task_form_task_scheduling.xml
+++ b/Habitica/res/layout/task_form_task_scheduling.xml
@@ -60,7 +60,8 @@
                 android:layout_height="wrap_content"
                 android:text="@string/repeats"
                 android:textColor="@color/gray_300"
-                android:textSize="12sp" />
+                android:textSize="12sp"
+                android:labelFor="@+id/repeats_every_spinner"/>
 
             <Spinner
                 android:id="@+id/repeats_every_spinner"
@@ -108,8 +109,9 @@
                     android:id="@+id/repeats_every_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    tools:text="@string/days"
-                    android:textColor="@color/gray_300"/>
+                    android:text="@string/days"
+                    android:textColor="@color/gray_300"
+                    android:labelFor="@+id/repeats_every_edittext"/>
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -1013,4 +1013,5 @@
     <string name="read_more">Read More</string>
     <string name="purchase_amount_error">You are unable to buy that amount.</string>
     <string name="still_questions">Still have a question?</string>
+    <string name="delete_checklist_entry">Delete Checklist entry</string>
 </resources>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -824,6 +824,7 @@
     <string name="invite_to_party">Invite to Party</string>
     <string name="are_you_sure">Are you sure?</string>
     <string name="delete_task">Delete Task</string>
+    <string name="delete_reminder">Delete Reminder</string>
     <string name="not_now">Not right now</string>
     <string name="levelup_detail_10">Choose a class that fits your playstyle and unlock special skills and armor to help you on your journey</string>
     <string name="levelup_title_10">Class System unlocked!</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="negative_habit_form">Negative</string>
     <string name="on">On</string>
     <string name="off">Off</string>
+    <string name="selected">Selected</string>
+    <string name="not_selected">Not selected</string>
     <string name="checklist">Checklist</string>
     <string name="reminders">Reminders</string>
 

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="start_date">Start Date</string>
     <string name="positive_habit_form">Positive</string>
     <string name="negative_habit_form">Negative</string>
+    <string name="on">On</string>
+    <string name="off">Off</string>
     <string name="checklist">Checklist</string>
     <string name="reminders">Reminders</string>
 

--- a/Habitica/res/values/styles.xml
+++ b/Habitica/res/values/styles.xml
@@ -636,6 +636,7 @@
         <item name="android:textColor">@color/gray_10</item>
         <item name="android:layout_marginTop">@dimen/spacing_large</item>
         <item name="android:layout_marginBottom">@dimen/spacing_medium</item>
+        <item name="android:accessibilityHeading">true</item>
     </style>
 
     <style name="TaskFormToggle">

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
@@ -41,6 +41,11 @@ class ChecklistItemFormView @JvmOverloads constructor(
     var animDuration = 0L
     var isAddButton: Boolean = true
     set(value) {
+        // Button is only clickable when it is *not* an add button (ie when it is a delete button),
+        // so make screenreaders skip it when it is an add button.
+        button.importantForAccessibility =
+                if (value) View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                else View.IMPORTANT_FOR_ACCESSIBILITY_YES
         if (field == value) {
             return
         }
@@ -83,11 +88,15 @@ class ChecklistItemFormView @JvmOverloads constructor(
                 (parent as? ViewGroup)?.removeView(this)
             }
         }
+        // It's ok to make the description always be 'Delete ..' because when this button is
+        // a plus button we set it as 'unimportant for accessibility' so it can't be focused.
+        button.contentDescription = context.getString(R.string.delete_checklist_entry)
         button.drawable.mutate().setTint(tintColor)
 
         editText.addTextChangedListener(OnChangeTextWatcher { s, _, _, _ ->
             item.text = s.toString()
             textChangedListener?.let { it(s.toString()) }
         })
+        editText.labelFor = button.id
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitResetStreakButtons.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitResetStreakButtons.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -22,7 +23,11 @@ class HabitResetStreakButtons @JvmOverloads constructor(
         field = value
         removeAllViews()
         addAllButtons()
+        selectedButton.sendAccessibilityEvent(
+                AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
     }
+
+    private lateinit var selectedButton: TextView
 
     init {
         addAllButtons()
@@ -43,14 +48,22 @@ class HabitResetStreakButtons @JvmOverloads constructor(
             button.gravity = Gravity.CENTER
             button.layoutParams = layoutParams
             addView(button)
+            if (resetOption == selectedResetOption) {
+                selectedButton = button;
+            }
         }
     }
 
     private fun createButton(resetOption: HabitResetOption): TextView {
+        val isActive = selectedResetOption == resetOption
+
         val button = TextView(context)
-        button.text = context.getString(resetOption.nameRes)
+        val buttonText = context.getString(resetOption.nameRes)
+        button.text = buttonText
+        button.contentDescription = toContentDescription(buttonText, isActive)
         button.background = ContextCompat.getDrawable(context, R.drawable.layout_rounded_bg_white)
-        if (selectedResetOption == resetOption) {
+
+        if (isActive) {
             button.background.setTint(tintColor)
             button.setTextColor(ContextCompat.getColor(context, R.color.white))
         } else {
@@ -61,5 +74,12 @@ class HabitResetStreakButtons @JvmOverloads constructor(
             selectedResetOption = resetOption
         }
         return button
+    }
+
+    private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {
+        val statusString = if (isActive) {
+            context.getString(R.string.selected)
+        } else context.getString(R.string.not_selected)
+        return "$buttonText, $statusString"
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitScoringButtonsView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/HabitScoringButtonsView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -18,7 +19,7 @@ class HabitScoringButtonsView @JvmOverloads constructor(
         context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
-    private val positiveVew: ViewGroup by bindView(R.id.positive_view)
+    private val positiveView: ViewGroup by bindView(R.id.positive_view)
     private val negativeView: ViewGroup by bindView(R.id.negative_view)
     private val positiveImageView: ImageView by bindView(R.id.positive_image_view)
     private val negativeImageView: ImageView by bindView(R.id.negative_image_view)
@@ -34,8 +35,10 @@ class HabitScoringButtonsView @JvmOverloads constructor(
             positiveImageView.setImageDrawable(HabiticaIconsHelper.imageOfHabitControlPlus(tintColor, value).asDrawable(resources))
             if (value) {
                 positiveTextView.setTextColor(tintColor)
+                positiveView.contentDescription = toContentDescription(R.string.positive_habit_form, R.string.on)
             } else {
                 positiveTextView.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
+                positiveView.contentDescription = toContentDescription(R.string.positive_habit_form, R.string.off)
             }
         }
 
@@ -45,20 +48,28 @@ class HabitScoringButtonsView @JvmOverloads constructor(
             negativeImageView.setImageDrawable(HabiticaIconsHelper.imageOfHabitControlMinus(tintColor, value).asDrawable(resources))
             if (value) {
                 negativeTextView.setTextColor(tintColor)
+                negativeView.contentDescription = toContentDescription(R.string.negative_habit_form, R.string.on)
             } else {
                 negativeTextView.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
+                negativeView.contentDescription = toContentDescription(R.string.negative_habit_form, R.string.off)
             }
         }
+
+    private fun toContentDescription(descriptionStringId: Int, statusStringId: Int): String {
+        return context.getString(descriptionStringId) + ", " + context.getString(statusStringId)
+    }
 
     init {
         View.inflate(context, R.layout.task_form_habit_scoring, this)
         gravity = Gravity.CENTER
 
-        positiveVew.setOnClickListener {
+        positiveView.setOnClickListener {
             isPositive = !isPositive
+            sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
         }
         negativeView.setOnClickListener {
             isNegative = !isNegative
+            sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION);
         }
 
         isPositive = true

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ReminderItemFormView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ReminderItemFormView.kt
@@ -5,6 +5,7 @@ import android.app.TimePickerDialog
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.LinearInterpolator
@@ -59,12 +60,16 @@ class ReminderItemFormView @JvmOverloads constructor(
                 rotate.interpolator = LinearInterpolator()
                 rotate.fillAfter = true
                 button.startAnimation(rotate)
+                // This button is not clickable in this state, so make screen readers skip it.
+                button.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
             } else {
                 val rotate = RotateAnimation(0f, 135f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
                 rotate.duration = animDuration
                 rotate.interpolator = LinearInterpolator()
                 rotate.fillAfter = true
                 button.startAnimation(rotate)
+                // This button IS now clickable, so allow screen readers to focus it.
+                button.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
             }
         }
 
@@ -80,6 +85,9 @@ class ReminderItemFormView @JvmOverloads constructor(
                 (parent as? ViewGroup)?.removeView(this)
             }
         }
+        // It's ok to make the description always be 'Delete Reminder' because when this button is
+        // a plus button we set it as 'unimportant for accessibility' so it can't be focused.
+        button.contentDescription = context.getString(R.string.delete_reminder)
         button.drawable.mutate().setTint(tintColor)
 
         textView.setOnClickListener {
@@ -99,6 +107,7 @@ class ReminderItemFormView @JvmOverloads constructor(
                 timePickerDialog.show()
             }
         }
+        textView.labelFor = button.id
     }
     override fun onTimeSet(view: TimePicker?, hourOfDay: Int, minute: Int) {
         valueChangedListener?.let {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskDifficultyButtons.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskDifficultyButtons.kt
@@ -3,6 +3,7 @@ package com.habitrpg.android.habitica.ui.views.tasks.form
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.view.accessibility.AccessibilityEvent
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Space
@@ -24,7 +25,9 @@ class TaskDifficultyButtons @JvmOverloads constructor(
         field = value
         removeAllViews()
         addAllButtons()
+        selectedButton.sendAccessibilityEvent(AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
     }
+    private lateinit var selectedButton: View
 
     init {
         addAllButtons()
@@ -41,6 +44,9 @@ class TaskDifficultyButtons @JvmOverloads constructor(
                 layoutParams.weight = 1f
                 space.layoutParams = layoutParams
                 addView(space)
+            }
+            if (difficulty.value == selectedDifficulty) {
+                selectedButton = button;
             }
         }
     }
@@ -59,10 +65,21 @@ class TaskDifficultyButtons @JvmOverloads constructor(
         }
         val drawable = HabiticaIconsHelper.imageOfTaskDifficultyStars(difficultyColor, difficulty.value, true).asDrawable(resources)
         view.findViewById<ImageView>(R.id.image_view).setImageDrawable(drawable)
-        view.findViewById<TextView>(R.id.text_view).text = context.getText(difficulty.nameRes)
+
+        val buttonText = context.getText(difficulty.nameRes)
+        view.findViewById<TextView>(R.id.text_view).text = buttonText
+        view.contentDescription = toContentDescription(buttonText, isActive)
+
         view.setOnClickListener {
             selectedDifficulty = difficulty.value
         }
         return view
+    }
+
+    private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {
+        val statusString = if (isActive) {
+            context.getString(R.string.selected)
+        } else context.getString(R.string.not_selected)
+        return "$buttonText, $statusString"
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
@@ -294,11 +294,13 @@ class TaskSchedulingControls @JvmOverloads constructor(
     private fun styleButtonAsActive(button: TextView) {
         button.setTextColor(ContextCompat.getColor(context, R.color.white))
         button.background.mutate().setTint(tintColor)
+        button.contentDescription = toContentDescription(button.text, true)
     }
 
     private fun styleButtonAsInactive(button: TextView) {
         button.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
         button.background.mutate().setTint(ContextCompat.getColor(context, R.color.taskform_gray))
+        button.contentDescription = toContentDescription(button.text, false)
     }
 
     private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
@@ -9,6 +9,7 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.widget.*
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.content.ContextCompat
@@ -226,6 +227,8 @@ class TaskSchedulingControls @JvmOverloads constructor(
             1 -> weeklyRepeat.su = isActive
         }
         createWeeklyRepeatViews()
+        weeklyRepeatWrapper.findViewWithTag<TextView>(weekday).sendAccessibilityEvent(
+                AccessibilityEvent.CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION)
     }
 
     private fun isWeekdayActive(weekday: Int): Boolean {
@@ -247,10 +250,12 @@ class TaskSchedulingControls @JvmOverloads constructor(
         val lastWeekday = weekdayOrder.last()
         for (weekdayCode in weekdayOrder) {
             val button = TextView(context, null, 0, R.style.TaskFormWeekdayButton)
+            val isActive = isWeekdayActive(weekdayCode)
             val layoutParams = LayoutParams(size, size)
             button.layoutParams = layoutParams
             button.text = weekdays[weekdayCode].first().toUpperCase().toString()
-            val isActive = isWeekdayActive(weekdayCode)
+            button.contentDescription = toContentDescription(weekdays[weekdayCode], isActive)
+            button.tag = weekdayCode
             if (isActive) {
                 button.background = context.getDrawable(R.drawable.habit_scoring_circle_selected)
                 button.background.mutate().setTint(tintColor)
@@ -291,6 +296,13 @@ class TaskSchedulingControls @JvmOverloads constructor(
             monthlyRepeatWeeksButton.setTextColor(unselectedText)
             monthlyRepeatWeeksButton.background.mutate().setTint(unselectedBackground)
         }
+    }
+
+    private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {
+        val statusString = if (isActive) {
+            context.getString(R.string.selected)
+        } else context.getString(R.string.not_selected)
+        return "$buttonText, $statusString"
     }
 
     private fun generateSummary() {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
@@ -279,23 +279,26 @@ class TaskSchedulingControls @JvmOverloads constructor(
     }
 
     private fun configureMonthlyRepeatViews() {
-        val white = ContextCompat.getColor(context, R.color.white)
-        val unselectedText = ContextCompat.getColor(context, R.color.gray_100)
-        val unselectedBackground = ContextCompat.getColor(context, R.color.taskform_gray)
         if (daysOfMonth != null && daysOfMonth?.isEmpty() != true) {
-            monthlyRepeatDaysButton.setTextColor(white)
-            monthlyRepeatDaysButton.background.mutate().setTint(tintColor)
+            styleButtonAsActive(monthlyRepeatDaysButton)
         } else {
-            monthlyRepeatDaysButton.setTextColor(unselectedText)
-            monthlyRepeatDaysButton.background.mutate().setTint(unselectedBackground)
+            styleButtonAsInactive(monthlyRepeatDaysButton)
         }
         if (weeksOfMonth != null && weeksOfMonth?.isEmpty() != true) {
-            monthlyRepeatWeeksButton.setTextColor(white)
-            monthlyRepeatWeeksButton.background.mutate().setTint(tintColor)
+            styleButtonAsActive(monthlyRepeatWeeksButton)
         } else {
-            monthlyRepeatWeeksButton.setTextColor(unselectedText)
-            monthlyRepeatWeeksButton.background.mutate().setTint(unselectedBackground)
+            styleButtonAsInactive(monthlyRepeatWeeksButton)
         }
+    }
+
+    private fun styleButtonAsActive(button: TextView) {
+        button.setTextColor(ContextCompat.getColor(context, R.color.white))
+        button.background.mutate().setTint(tintColor)
+    }
+
+    private fun styleButtonAsInactive(button: TextView) {
+        button.setTextColor(ContextCompat.getColor(context, R.color.gray_100))
+        button.background.mutate().setTint(ContextCompat.getColor(context, R.color.taskform_gray))
     }
 
     private fun toContentDescription(buttonText: CharSequence, isActive: Boolean): String {


### PR DESCRIPTION
Third set of improvements towards making the whole app work well with Talkback - issue #180 . This PR supersedes PR #1311.

- Previously when Talkback was enabled, it would read out all the button labels, but not whether they were currently selected - this was only represented visually by the colour of the buttons.

- Now, Talkback also reads out the current state (on/off, selected/not selected) of the following buttons:
  - New Habit screen:
    - Positive / negative habit buttons
    - Task difficulty buttons
    - Reset streak buttons
  - New Daily screen:
    - Weekday buttons
    - Weekly repeats buttons (this involved a small refactor, pulled out as a separate commit)

- This involved some code duplication, especially between the task difficulty buttons & reset streak buttons code. However, the logic being duplicated is fairly simple, so I think this is acceptable for now (especially given the classes already contain a fair amount of duplication.. but perhaps a larger refactor to eliminate this is due in future?).

- I improved some content descriptions by setting which view they were a label for.

- I improved the content description of the add / delete checklist entry / reminder buttons on the New Daily screen.

- I also added `android:accessibilityHeading="true"` to the style of all headings in activity_task_view.xml - as advised at https://developer.android.com/guide/topics/ui/accessibility/principles#headings_within_text - so these are now read out as headings by Talkback.

my Habitica User-ID: 41882d4c-652f-4212-bbf5-9f0e90badd14