### PR TITLE
Add content descriptions to menu drawer items

### DIFF
--- a/Habitica/res/layout/drawer_main.xml
+++ b/Habitica/res/layout/drawer_main.xml
@@ -68,7 +68,8 @@
                 android:background="@color/transparent"
                 android:src="@drawable/menu_notifications"
                 android:layout_centerVertical="true"
-                android:clickable="false" />
+                android:clickable="false"
+                android:contentDescription="@string/notifications" />
 
             <TextView
                 android:id="@+id/notificationsBadge"
@@ -100,7 +101,8 @@
                 android:background="@color/transparent"
                 android:src="@drawable/menu_messages"
                 android:layout_centerVertical="true"
-                android:clickable="false" />
+                android:clickable="false"
+                android:contentDescription="@string/inbox" />
 
             <TextView
                 android:id="@+id/messagesBadge"
@@ -131,8 +133,8 @@
                 android:layout_height="wrap_content"
                 android:background="@color/transparent"
                 android:src="@drawable/menu_settings"
-                android:layout_centerVertical="true"/>
-
+                android:layout_centerVertical="true"
+                android:contentDescription="@string/PS_settings_title" />
             <TextView
                 android:id="@+id/settingsBadge"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Improvement towards making the whole app work well with Talkback - issue #180 .

Now Talkback reads out 'Notifications, [number]', 'Messages', and 'Settings' if a user swipes through these icons in the navigation drawer with Talkback enabled. (Previously the ImageView content descriptions were not set, so only the number of notifications were read out).

my Habitica User-ID:41882d4c-652f-4212-bbf5-9f0e90badd14
