### PR TITLE
Fix grammar mistake on empty Special items page

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/items/ItemRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/items/ItemRecyclerFragment.kt
@@ -25,6 +25,7 @@ import com.habitrpg.android.habitica.ui.helpers.*
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.Companion.showSnackbar
 import io.reactivex.functions.Consumer
+import java.util.Locale
 import javax.inject.Inject
 
 class ItemRecyclerFragment : BaseFragment() {
@@ -64,13 +65,20 @@ class ItemRecyclerFragment : BaseFragment() {
         component.inject(this)
     }
 
+    private fun noItemsSuffix(): String {
+        return when(itemType) {
+            "special" -> " " + getString(R.string.sidebar_items).toLowerCase(Locale.getDefault())
+            else -> ""
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         resetViews()
 
         recyclerView?.setEmptyView(emptyView)
-        emptyTextView?.text = getString(R.string.empty_items, itemTypeText)
+        emptyTextView?.text = getString(R.string.empty_items, itemTypeText + noItemsSuffix())
 
         val context = activity
 


### PR DESCRIPTION
When you have no special items the following grammatically incorrect message is displayed
You don't have any Special
This is a special (hehe) case because the other item types already work in a plural context.

This commit changes that message to the following
You don't have any Special items
Or the equivalent in the user's language.

This may not be correct for right to left languages, as I have placed a space between Special and items. I have no way to verify this and don't know how to solve it if it is an issue.

my Habitica User-ID: `@Andriak`
