### PR TITLE
Fixed can't add more than one task on challenge form

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ChallengeFormActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ChallengeFormActivity.kt
@@ -460,6 +460,11 @@ class ChallengeFormActivity : BaseActivity() {
                 Task.TYPE_TODO -> addTodo
                 else -> addReward
             }
+            if(!isExistingTask){
+                // If the task is new we create a unique id for it
+                // Doing it we solve the issue #1278
+                task.id = UUID.randomUUID().toString()
+            }
 
             challengeTasks.addTaskUnder(task, taskAbove)
 


### PR DESCRIPTION
Issue: #1278  The problem was the task added on the screen do not had an id, so when we were adding a new task, the [function](https://github.com/HabitRPG/habitica-android/blob/efce4158b559e9f11f7f87382e082ba9890823c7/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/social/challenges/ChallengeTasksRecyclerViewAdapter.kt#L91) to know if is a new task or an existing task on the screen return "true" because the ids were the same: null == null.

- We fix it creating an id when the task is a new one

my Habitica User-ID: 4fcc9225-742f-43bd-92f9-b81e43ea86ea
