### PR TITLE
Fix default todo filters on boot

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
@@ -163,12 +163,15 @@ open class TaskRecyclerViewFragment : BaseFragment<FragmentRefreshRecyclerviewBi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         context?.let { binding?.recyclerView?.setBackgroundColor(ContextCompat.getColor(it, R.color.content_background)) }
-        if (Task.TYPE_DAILY == classType) {
-            if (user?.isValid == true && user?.preferences?.dailyDueDefaultView == true) {
-                taskFilterHelper.setActiveFilter(Task.TYPE_DAILY, Task.FILTER_ACTIVE)
+        savedInstanceState?.let { this.classType = savedInstanceState.getString(CLASS_TYPE_KEY, "") }
+
+        when (classType) {
+            Task.TYPE_TODO -> taskFilterHelper.setActiveFilter(Task.TYPE_TODO, Task.FILTER_ACTIVE)
+            Task.TYPE_DAILY -> {
+                if (user?.isValid == true && user?.preferences?.dailyDueDefaultView == true) {
+                    taskFilterHelper.setActiveFilter(Task.TYPE_DAILY, Task.FILTER_ACTIVE)
+                }
             }
-        } else if (Task.TYPE_TODO == classType) {
-            taskFilterHelper.setActiveFilter(Task.TYPE_TODO, Task.FILTER_ACTIVE)
         }
 
         itemTouchCallback = object : ItemTouchHelper.Callback() {
@@ -229,9 +232,6 @@ open class TaskRecyclerViewFragment : BaseFragment<FragmentRefreshRecyclerviewBi
                             }, RxErrorHandler.handleEmptyError()))
                 }
             }
-        }
-        if (savedInstanceState != null) {
-            this.classType = savedInstanceState.getString(CLASS_TYPE_KEY, "")
         }
 
         binding?.recyclerView?.setScaledPadding(context, 0, 0, 0, 48)


### PR DESCRIPTION
This fixes Issue #1319.

Steps to reproduce bugged behavior:
1. Open Habitica
2. Complete a Todo task.
3. Close the app (important: while still on the todo fragment)
4. Set the background process limit to 0
    * Developer options -> Background process limit -> "no background processes"
5. Open another app
    * From my understanding, this will remove as much app state from the device memory as possible without actually force stopping the app
6. Open Habitica
    * The app will seem like it's cold booting, but it's actually going to restore into the todo fragment instead of the habit fragment

My Habitica User-ID: 99f20106-7060-4398-b565-26e56c4de2ad

| Bugged Behavior | Fixed Behavior |
| ----------------- | --------------- |
| ![1319 repro](https://user-images.githubusercontent.com/22078613/94201242-bd697080-fe89-11ea-8ffb-7d5bcb7cddbc.gif) | ![1319 fixed](https://user-images.githubusercontent.com/22078613/94201245-bf333400-fe89-11ea-8d78-3ef11e87a12e.gif) |