### PR TITLE
Fix odd appearance on Settings page when using an RTL(Right to left) languages

### DIFF
--- a/Habitica/res/layout/preference_child_summary.xml
+++ b/Habitica/res/layout/preference_child_summary.xml
@@ -36,7 +36,7 @@
         android:id="@android:id/summary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignLeft="@android:id/title"
+        android:layout_alignStart="@android:id/title"
         android:layout_below="@android:id/title"
         android:maxLines="4"
         android:textAppearance="?android:attr/textAppearanceSmall"


### PR DESCRIPTION
### Summary
This pull request is to resolve issue #1427. The problem was in the alignment properties of the summary TextView, with the old properties of alignment the TextView moved in a no desire way when the app was mirrored for an RTL language
### Changes
- Modify `preference_child_summary.xml`
### Target
`develop`

my Habitica User-ID: 78b5d1f8-b295-4f95-9541-3d1b418358c0
