### PR TITLE
Fix "unable to buy that amount" appearing when viewing quests in inventory

### DIFF
--- a/Habitica/res/layout/dialog_purchase_content_quest.xml
+++ b/Habitica/res/layout/dialog_purchase_content_quest.xml
@@ -179,13 +179,4 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"/>
-    <TextView
-        android:id="@+id/amount_error_label"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:text="@string/purchase_amount_error"
-        android:textSize="12sp"
-        android:textColor="@color/text_ternary"
-        android:layout_marginTop="@dimen/spacing_medium"
-        android:gravity="center_horizontal"/>
 </merge>


### PR DESCRIPTION
**Summary**

This pull request fixes issue #1423.

`amount_error_label` was added to the layout when it was not necessary. There were no references to this component in PurchaseDialogQuestContent.kt file, which could toggle its visibility, meaning that "unable to buy that amount" text will always be visible in mentioned dialog.

**Screenshot with fix**
![quest_dialog_fixed](https://user-images.githubusercontent.com/31341111/101283010-d8892280-37e0-11eb-9ca2-69e942d7e9f3.PNG)

**Changes**
- Modify `dialog_purchase_content_quest.xml` by removing `amount_error_label` element
- There were **NO** changes done to `dialog_purchase_gems.xml` which is the subscriber gem modal

**Target**
`develop`

my Habitica User-ID: 8e48135f-b553-42b7-ab5e-d58d45e36ee2