### PR TITLE
Fix double cancel invitation buttons appearing

### DIFF
--- a/Habitica/res/layout/fragment_quest_detail.xml
+++ b/Habitica/res/layout/fragment_quest_detail.xml
@@ -146,8 +146,9 @@
                 android:id="@+id/quest_leave_button"
                 android:layout_width="0dp"
                 android:layout_weight="1"
+                android:layout_marginEnd="8dp"
                 android:layout_height="wrap_content"
-                android:text="@string/quest_cancel"
+                android:text="@string/leave"
                 style="@style/HabiticaButton.Red" />
 
             <Button


### PR DESCRIPTION
Fixes issue #1452 
There were double cancel invitation buttons appearing instead of one Leave and one Cancel Invitation button. Therefore I replaced one Cancel Invitation button with a Leave button.

my Habitica User-ID: NA
