### PR TITLE
fix: increase contrast for timePicker buttons in new task from 1.6 to 4.5

### DIFF
--- a/Habitica/res/values-night/colors.xml
+++ b/Habitica/res/values-night/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="brand">@color/brand_400</color>
     <color name="color_accent">@color/brand_400</color>
     <color name="text_primary">@color/gray_600</color>
     <color name="text_secondary">@color/gray_500</color>


### PR DESCRIPTION
This fixes the problem outlined in the second screenshot of #1501

my Habitica User-ID: 9ff09613-fd71-410e-813c-93d06ce601eb
