### PR TITLE
904 chat markdown images

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/ChatMessage.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/ChatMessage.kt
@@ -1,6 +1,7 @@
 package com.habitrpg.android.habitica.models.social
 
 import android.renderscript.BaseObj
+import android.text.Spanned
 import com.habitrpg.android.habitica.models.BaseObject
 import com.habitrpg.android.habitica.models.user.Backer
 import com.habitrpg.android.habitica.models.user.ContributorInfo
@@ -32,7 +33,7 @@ open class ChatMessage : RealmObject(), BaseObject {
     var text: String? = null
 
     @Ignore
-    var parsedText: CharSequence? = null
+    var parsedText: Spanned? = null
 
     var timestamp: Long? = null
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/ChatRecyclerViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/ChatRecyclerViewHolder.kt
@@ -26,6 +26,7 @@ import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import com.habitrpg.android.habitica.models.members.Member
+import com.habitrpg.android.habitica.ui.helpers.setParsedMarkdown
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar
 import com.habitrpg.android.habitica.ui.views.dialogs.HabiticaAlertDialog
 import org.greenrobot.eventbus.EventBus
@@ -172,7 +173,7 @@ class ChatRecyclerMessageViewHolder(itemView: View, private var userId: String, 
             itemView.setPadding(16.dpToPx(context), itemView.paddingTop, itemView.paddingRight, itemView.paddingBottom)
         }
 
-        binding.messageText.text = chatMessage?.parsedText
+        binding.messageText.setParsedMarkdown(chatMessage?.parsedText)
         if (msg.parsedText == null) {
             binding.messageText.text = chatMessage?.text
             Maybe.just(chatMessage?.text ?: "")
@@ -181,7 +182,7 @@ class ChatRecyclerMessageViewHolder(itemView: View, private var userId: String, 
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({ parsedText ->
                         chatMessage?.parsedText = parsedText
-                        binding.messageText.text = chatMessage?.parsedText
+                        binding.messageText.setParsedMarkdown(parsedText)
                     }, { it.printStackTrace() })
         }
 


### PR DESCRIPTION
Fixes #904 
my Habitica User-ID: fa756acf-9127-4a3c-8dac-8ff627d30073

The first commit adds the actual image support to chat messages. But the images were really small (here's a screenshot from the emulator and the same messages in a web browser):

![Screenshot from 2021-03-11 23-01-56](https://user-images.githubusercontent.com/1764167/110902168-16c93d00-830e-11eb-8f89-d68c12a89c57.png)

![Screenshot from 2021-03-11 22-59-50](https://user-images.githubusercontent.com/1764167/110902180-1d57b480-830e-11eb-8584-fdd11332b9eb.png)


So the second commit adds a custom markwon plugin that scales the images according to device dpi, so that the final result looks like this:

![Screenshot from 2021-03-12 08-17-52](https://user-images.githubusercontent.com/1764167/110902258-3e200a00-830e-11eb-98f9-19bdb60518db.png)

Haven't tested the scaling thing on more than the Pixel 2 emulator yet, but I tried to make it safe (only scale if dpi > 1 and make sure that images fit to the canvas). 

Note, the image scaling affects all images rendered using this markwon instance, so it affects also the other places besides just chat messages. But from what I've seen on my own Android device the images in e.g. guild and challenge descriptions tend to show up smaller than on the website, so I think that scaling is probably desirable there too. Not sure about images used in task titles/descriptions, since I haven't used those.

