### PR TITLE
1460 phantom pet eggs

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmInventoryLocalRepository.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmInventoryLocalRepository.kt
@@ -229,6 +229,7 @@ class RealmInventoryLocalRepository(realm: Realm) : RealmContentLocalRepository(
             "hatchingPotions" -> HatchingPotion::class.java
             "food" -> Food::class.java
             "quests" -> QuestContent::class.java
+            "special" -> SpecialItem::class.java
             else -> Egg::class.java
         }
         return RxJavaBridge.toV3Flowable(realm.where(itemClass).equalTo("key", key).findFirstAsync().asFlowable<RealmObject>()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/SpecialItems.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/SpecialItems.kt
@@ -14,7 +14,7 @@ open class SpecialItems : RealmObject() {
             ownedItems?.forEach {
                 if (!it.isManaged) {
                     it.userID = userId
-                    it.itemType = "eggs"
+                    it.itemType = "special"
                 }
             }
         }


### PR DESCRIPTION
This fixes the issue of eggs with title `inventory_present` show in Items > Eggs (from issue #1460). Found out that they are actually the Mystery items that get mistakenly categorized as eggs when updating user data.

That change in `SpecialItems.kt` is the one that actually fixes the problem, but I made that other change too since it felt like appropriate (and I first landed there and thought it was the cause of the issue) as I thought the list should match this other one: https://github.com/HabitRPG/habitica-android/blob/ff6dac2aae34f6a9a07fbf1420ad11e8d2c0ee28/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/items/ItemRecyclerFragment.kt#L219-L226

The problem was not shown initially when you go to the Items view, but appeared sometime later. I found out that setter method in SpecialItems is called from https://github.com/HabitRPG/habitica-android/blob/ff6dac2aae34f6a9a07fbf1420ad11e8d2c0ee28/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/Items.kt#L18 which is called from https://github.com/HabitRPG/habitica-android/blob/ff6dac2aae34f6a9a07fbf1420ad11e8d2c0ee28/Habitica/src/main/java/com/habitrpg/android/habitica/models/user/User.kt#L112 which is called by `mergeUser` in https://github.com/HabitRPG/habitica-android/blob/ff6dac2aae34f6a9a07fbf1420ad11e8d2c0ee28/Habitica/src/main/java/com/habitrpg/android/habitica/data/implementation/UserRepositoryImpl.kt#L412 which happens when you go the Settings view.

my Habitica User-ID: fa756acf-9127-4a3c-8dac-8ff627d30073
