### PR TITLE
Fixed accessibility focus on Daily checkbox and todo checkbox. fixed transaction ran on button click.

### DIFF
--- a/Habitica/res/layout/daily_item_card.xml
+++ b/Habitica/res/layout/daily_item_card.xml
@@ -26,7 +26,9 @@
                     android:id="@+id/checkBoxHolder"
                     android:layout_width="@dimen/button_width"
                     android:layout_height="match_parent"
-                    tools:background="@color/red_10">
+                    tools:background="@color/red_10"
+                    android:focusable="true"
+                    android:contentDescription="@string/daily_item_checkbox">
                     <View
                         android:id="@+id/checkBoxBackground"
                         android:layout_width="24dp"

--- a/Habitica/res/layout/todo_item_card.xml
+++ b/Habitica/res/layout/todo_item_card.xml
@@ -27,7 +27,9 @@
                     android:id="@+id/checkBoxHolder"
                     android:layout_width="@dimen/button_width"
                     android:layout_height="match_parent"
-                    tools:background="@color/red_10">
+                    tools:background="@color/red_10"
+                    android:focusable="true"
+                    android:contentDescription="@string/todo_item_checkbox">
                     <View
                         android:id="@+id/checkBoxBackground"
                         android:layout_width="24dp"

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -1166,4 +1166,6 @@
     <string name="locked_equipment_shop_dialog">You must purchase the previous items in this sequence to unlock</string>
     <string name="caused_damage">You caused damage to the boss</string>
     <string name="avatar_style">Style</string>
+    <string name="daily_item_checkbox">Daily Checkbox</string>
+    <string name="todo_item_checkbox">Todo Checkbox</string>
 </resources>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/implementation/TaskRepositoryImpl.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/implementation/TaskRepositoryImpl.kt
@@ -175,7 +175,7 @@ class TaskRepositoryImpl(localRepository: TaskLocalRepository, apiClient: ApiCli
                 }
             }
 
-            val stats = bgUser.stats
+            val stats = it.copyFromRealm(bgUser.stats)
             stats?.hp = res.hp
             stats?.exp = res.exp
             stats?.mp = res.mp


### PR DESCRIPTION
Addresses #1540 

The user was not able to select the Daily checkbox. I made it focusable and added a content description.
I found the same issue was happening in the Todo list, so fixed that too.

While I was working on this fix, I noticed that when I click any task buttons, it caused an error from Realm that Object is not available. This caused DB to update, but UI got out of sync.
I read the code and found that we are storing an object by reference and there is a section in Realm that deletes this object, replacing it with a new Proxy object. That's why the object was becoming unavailable.
So I replaced the reference with a copyFromRealm, which will create a copy of the variable instead of a mutable reference.

My Habitica User-ID: _trion
