### PR TITLE
Fix Enchanted Armoire Item Displays Wrong Error Message

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/shops/PurchaseDialog.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/shops/PurchaseDialog.kt
@@ -168,7 +168,7 @@ class PurchaseDialog(context: Context, component: UserComponent?, val item: Shop
     @OptIn(ExperimentalTime::class)
     private fun setLimitedTextView() {
         if (user == null) return
-        if (shopItem.habitClass != null && shopItem.habitClass != "special" && user?.stats?.habitClass != shopItem.habitClass) {
+        if (shopItem.habitClass != null && shopItem.habitClass != "special" && shopItem.habitClass != "armoire" && user?.stats?.habitClass != shopItem.habitClass) {
             limitedTextView.text = context.getString(R.string.class_equipment_shop_dialog)
             limitedTextView.visibility = View.VISIBLE
             limitedTextView.setBackgroundColor(ContextCompat.getColor(context, R.color.inverted_background))


### PR DESCRIPTION
Fix for #1691 
my Habitica User-ID: ebeec288-bdae-4e6e-bd6e-040cb8a1d7ba


With not enough gold, dialog becames:
<img src="https://user-images.githubusercontent.com/22160644/150476358-7652e003-f4bd-4181-9289-0659428a1f62.png" alt="error-no-money" width="300"/><img src="https://user-images.githubusercontent.com/22160644/150476360-dc0bab23-3a77-43e6-bd46-9b03d2198746.png" alt="no-error-no-money" width="300"/>

With enough gold, dialog becames:
<img src="https://user-images.githubusercontent.com/22160644/150476366-9f5dc302-a35f-4a6a-9aeb-a4d69f3baf4c.png" alt="error-buy" width="300"/><img src="https://user-images.githubusercontent.com/22160644/150476368-43e3fe3c-ff91-4115-bf06-be41a4819964.png" alt="no-error-buy" width="300"/>


It can be purchased as usual:
<img src="https://user-images.githubusercontent.com/22160644/150476371-d6fd66fd-37b0-4362-adc3-f86714f16e2c.png" alt="purchased" width="300"/>
