### PR TITLE
Pluralize warrior to warriors for final sentence in class description

### DIFF
--- a/Habitica/res/values-en-rGB/strings.xml
+++ b/Habitica/res/values-en-rGB/strings.xml
@@ -471,7 +471,7 @@
 \n • Tasks won’t lose streaks or decay in colour
 \n • Bosses won’t do damage for your missed Dailies
 \n • Your boss damage or collection quest items will stay pending until check-out</string>
-    <string name="warrior_description">Warriors score more critical hits and deal heavy damage to Bosses. Play a Warrior if you want to defeat monsters easily! Warrior benefit from a high Strength stat.</string>
+    <string name="warrior_description">Warriors score more critical hits and deal heavy damage to Bosses. Play a Warrior if you want to defeat monsters easily! Warriors benefit from a high Strength stat.</string>
     <string name="opting_out_progress">Opting Out</string>
     <string name="change_class_description">Change your class and refund your stat points for 3 gems.</string>
     <string name="invite_username_description">If you have friends already using Habitica, invite them by username here.</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -303,7 +303,7 @@
     <string name="rogue">Rogue</string>
     <string name="mage">Mage</string>
     <string name="healer">Healer</string>
-    <string name="warrior_description">Warriors score more critical hits and deal heavy damage to Bosses. Play a Warrior if you want to defeat monsters easily! Warrior benefit from a high Strength stat.</string>
+    <string name="warrior_description">Warriors score more critical hits and deal heavy damage to Bosses. Play a Warrior if you want to defeat monsters easily! Warriors benefit from a high Strength stat.</string>
     <string name="mage_description">Mages learn Skills that damage Bosses and boost EXP and Mana. Play a Mage if you’re motivated by leveling up quickly! Mages benefit from a high Intelligence stat.</string>
     <string name="rogue_description">Rogues learn Skills that let them and their Party find more Gold and random drops. Play a Rogue if you want lots of items and Gold! Rogues benefit from a high Perception stat.</string>
     <string name="healer_description">Healers learn Skills that can heal and protect themselves and their Party. Play a Healer if you enjoy assisting others or avoiding damage! Healers benefit from a high Constitution stat.</string>


### PR DESCRIPTION
### Problem
In the warrior class description when choosing a class, the final sentence reads "Warrior benefit from a high Strength stat.":
<img src="https://user-images.githubusercontent.com/1057406/151557560-8d7891a1-659b-46d2-b22b-2daa0b3f92d0.png" width="250" />

### Solution
Pluralize warrior in this sentence to make it the grammatically correct "Warriors benefit from a high Strength stat." 
I checked this for English strings (including `en-rGB`), but I'm not sure if the same issue exists in other languages.


**my Habitica User-ID**: caef89d8-3a3d-4d3b-a5ad-67cb0455a56e
