### PR TITLE
Fixes#1258 - Fixed reminders occurring randomly or not at all

### DIFF
--- a/Habitica/AndroidManifest.xml
+++ b/Habitica/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
@@ -1,6 +1,7 @@
 package com.habitrpg.android.habitica.helpers
 
 import android.app.AlarmManager
+import android.app.AlarmManager.AlarmClockInfo
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -174,7 +175,7 @@ class TaskAlarmManager(private var context: Context, private var taskRepository:
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                 alarmManager?.setWindow(AlarmManager.RTC_WAKEUP, time, 60000, pendingIntent)
             } else {
-                alarmManager?.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, time, pendingIntent)
+                alarmManager?.setAlarmClock(AlarmClockInfo(time, pendingIntent), pendingIntent)
             }
         }
     }


### PR DESCRIPTION
Replace setAndAllowWhileIdle with setAlarmClock due to both setAndAllowWhileIdle and setExactAndAllowWhileIdle have triggering alarm restrictions - setAlarmClock is exact and does not limit alarm count.