### PR TITLE
Fixes#1637 - Fix users unable to purchase gems because "you already own this item"

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/PurchaseHandler.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/PurchaseHandler.kt
@@ -103,14 +103,7 @@ open class PurchaseHandler(
             override fun onBillingSetupFinished(billingResult: BillingResult) {
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                     billingClientState = BillingClientState.READY
-                    billingClient.queryPurchasesAsync(
-                        BillingClient.SkuType.SUBS,
-                        this@PurchaseHandler
-                    )
-                    billingClient.queryPurchasesAsync(
-                        BillingClient.SkuType.INAPP,
-                        this@PurchaseHandler
-                    )
+                    queryPurchases()
                 } else {
                     billingClientState = BillingClientState.UNAVAILABLE
                 }
@@ -124,6 +117,19 @@ open class PurchaseHandler(
 
     fun stopListening() {
         billingClient.endConnection()
+    }
+
+    fun queryPurchases(){
+        if (billingClientState == BillingClientState.READY){
+            billingClient.queryPurchasesAsync(
+                BillingClient.SkuType.SUBS,
+                this@PurchaseHandler
+            )
+            billingClient.queryPurchasesAsync(
+                BillingClient.SkuType.INAPP,
+                this@PurchaseHandler
+            )
+        }
     }
 
     suspend fun getAllGemSKUs(): List<SkuDetails> =

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/purchases/GemsPurchaseFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/purchases/GemsPurchaseFragment.kt
@@ -91,6 +91,7 @@ class GemsPurchaseFragment : BaseFragment<FragmentGemPurchaseBinding>() {
 
     override fun onResume() {
         super.onResume()
+        purchaseHandler.queryPurchases()
         loadInventory()
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/purchases/SubscriptionFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/purchases/SubscriptionFragment.kt
@@ -102,6 +102,7 @@ class SubscriptionFragment : BaseFragment<FragmentSubscriptionBinding>() {
 
     override fun onResume() {
         super.onResume()
+        purchaseHandler.queryPurchases()
         refresh()
         loadInventory()
     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/insufficientCurrency/InsufficientGemsDialog.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/insufficientCurrency/InsufficientGemsDialog.kt
@@ -49,6 +49,8 @@ class InsufficientGemsDialog(context: Context, var gemPrice: Int) : Insufficient
         addCloseButton()
     }
 
+
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         getActivity()?.let { activity ->


### PR DESCRIPTION
queryPurchasesAsync was moved from init block to onResume (per Android billing documentation).

onQueryPurchasesResponse was not returning purchases that needed to be consumed if onPurchasesUpdated did not catch them due to queryPurchasesAsync being run on init block.

