### PR TITLE
Fixes#1716 - Fix party launch not working reliably

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
@@ -287,9 +287,12 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
         MainNavigationController.setup(navigationController)
         navigationController.addOnDestinationChangedListener { _, destination, arguments -> updateToolbarTitle(destination, arguments) }
 
+
         if (launchScreen == "/party") {
-            if (viewModel.userViewModel.isUserInParty) {
-                MainNavigationController.navigate(R.id.partyFragment)
+            viewModel.user.observeOnce(this) {
+                if (viewModel.userViewModel.isUserInParty) {
+                    MainNavigationController.navigate(R.id.partyFragment)
+                }
             }
         }
         launchScreen = null


### PR DESCRIPTION
Await observer (once) to check if user is currently has party set as launch, and navigate to Party screen.