### PR TITLE
Reminder fix

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
@@ -75,8 +75,7 @@ class TaskAlarmManager(
     }
 
     private fun setTimeForDailyReminder(remindersItem: RemindersItem?, task: Task): RemindersItem? {
-        val oldTime = remindersItem?.time
-        val newTime = (task.getNextReminderOccurence(oldTime) ?: return null)
+        val newTime = (task.getNextReminderOccurence(remindersItem) ?: return null)
 
         remindersItem?.time = newTime.withZoneSameLocal(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -187,24 +187,27 @@ open class Task : RealmObject, BaseMainObject, Parcelable {
 
     fun checkIfDue(): Boolean = isDue == true
 
-    fun getNextReminderOccurence(oldTime: String?): ZonedDateTime? {
-        if (oldTime == null) {
-            return null
-        }
-        val nextDate = nextDue?.firstOrNull()
+    fun getNextReminderOccurence(remindersItem: RemindersItem?): ZonedDateTime? {
+        if (remindersItem != null) {
+            remindersItem.time?.let {
+                val oldTime = it
+                val now = ZonedDateTime.now().withZoneSameLocal(ZoneId.systemDefault())?.toInstant()
+                val nextDate = nextDue?.firstOrNull()
 
-        return if (nextDate != null && !isDisplayedActive) {
-            val nextDueCalendar = GregorianCalendar()
-            nextDueCalendar.time = nextDate
-            parse(oldTime)
-                ?.withYear(nextDueCalendar.get(Calendar.YEAR))
-                ?.withMonth(nextDueCalendar.get(Calendar.MONTH))
-                ?.withDayOfMonth(nextDueCalendar.get(Calendar.DAY_OF_MONTH))
-        } else if (isDisplayedActive) {
-            parse(oldTime)
-        } else {
-            null
+                return if (nextDate != null && (!isDisplayedActive || remindersItem.getLocalZonedDateTimeInstant()?.isBefore(now) == true)) {
+                    val nextDueCalendar = GregorianCalendar()
+                    nextDueCalendar.time = nextDate
+                    parse(oldTime)
+                        ?.withYear(nextDueCalendar.get(Calendar.YEAR))
+                        ?.withMonth(nextDueCalendar.get(Calendar.MONTH) + 1) //+1 to handle Gregorian Calendar month range from 0-11
+                        ?.withDayOfMonth(nextDueCalendar.get(Calendar.DAY_OF_MONTH))
+                } else {
+                    return parse(oldTime)
+                }
+            }
+
         }
+        return null
     }
 
     fun formatter(): DateTimeFormatter =


### PR DESCRIPTION
Fix reminders not scheduling consistently

Fix Examples:
If it's currently 1:00pm, and the user sets a daily for 4:00pm same day, the reminder will show at 4:00pm.

If the user did not mark the reminder as complete at 4:00pm the same day, when the next day comes around the reminder will show at 4:00pm regardless if they marked the task as complete the day before. HOWEVER - the user will still receive the reminder at 4:00pm even if they marked the task as complete say at 3:00pm that day. (Currently a band-aid fix while in Draft until I have a chance to pick Phillip's brain c: )

