### PR TITLE
Armoire drop rate sheet ui fixes

### DIFF
--- a/Habitica/res/layout/armoire_drop_rate_dialog.xml
+++ b/Habitica/res/layout/armoire_drop_rate_dialog.xml
@@ -9,9 +9,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/enchanted_armoire_drop_rates"
-        style="@style/Title1"
+        style="@style/ArmoireTitleTextView"
+        android:gravity="center_horizontal"
         android:textAlignment="center"
-        android:textColor="@color/text_primary"
         android:layout_marginBottom="18dp"
         />
     <TextView
@@ -23,9 +23,8 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@color/text_secondary"
         android:text="@string/armoire_rate_equipment_description"
-        style="@style/Caption2"
+        style="@style/ArmoireDescriptionTextView"
         android:layout_marginBottom="12dp"
         />
 
@@ -38,9 +37,8 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@color/text_secondary"
         android:text="@string/armoire_rate_food_description"
-        style="@style/Caption2"
+        style="@style/ArmoireDescriptionTextView"
         android:layout_marginBottom="12dp"
         />
 
@@ -53,8 +51,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@color/text_secondary"
         android:text="@string/armoire_rate_experience_description"
-        style="@style/Caption2"
+        style="@style/ArmoireDescriptionTextView"
         />
 </LinearLayout>

--- a/Habitica/res/values-night/colors.xml
+++ b/Habitica/res/values-night/colors.xml
@@ -64,6 +64,8 @@
     <color name="text_brand_white">@color/white</color>
     <color name="lightly_tinted_background">@color/brand_50</color>
     <color name="dialog_background">@color/gray_10</color>
+    <color name="armoire_text">@color/gray_400</color>
+
 
     <color name="widget_background">#2B203A</color>
 </resources>

--- a/Habitica/res/values/colors.xml
+++ b/Habitica/res/values/colors.xml
@@ -33,6 +33,7 @@
     <color name="task_secondary_text">#B2B2B2</color>
     <color name="gem_icon_color">#24cc8f</color>
     <color name="subscription_description_text">#b1000000</color>
+    <color name="armoire_text">@color/gray_200</color>
     <color name="white_95_alpha">#f2ffffff</color>
     <color name="white_80_alpha">#ccffffff</color>
     <color name="white_75_alpha">#bfffffff</color>

--- a/Habitica/res/values/styles.xml
+++ b/Habitica/res/values/styles.xml
@@ -740,6 +740,20 @@
         <item name="android:gravity">center</item>
     </style>
 
+    <style name="ArmoireTitleTextView">
+        <item name="android:fontFamily">@string/font_family_medium</item>
+        <item name="android:textSize">20sp</item>
+        <item name="android:letterSpacing">0.07</item>
+        <item name="android:textColor">@color/armoire_text</item>
+    </style>
+
+    <style name="ArmoireDescriptionTextView">
+        <item name="android:fontFamily">@string/font_family_regular</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">@color/armoire_text</item>
+    </style>
+
     <style name="QuestRatingBar" parent="@android:style/Widget.RatingBar">
         <item name="android:progressDrawable">@drawable/quest_difficulty_rating</item>
         <item name="android:minHeight">12dip</item>


### PR DESCRIPTION
Title Centered
Top line gray 400 in dark mode, 200 in light mode
Supporting text for each category is now regular roboto
Supporting text for each category is gray 400 in dark mode, 200 in light mode