### PR TITLE
Set audio to play at Media volume (Issue #1844)

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/SoundFile.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/SoundFile.kt
@@ -37,7 +37,7 @@ class SoundFile(val theme: String, private val fileName: String) {
             player?.setDataSource(file?.path)
             val attributes = AudioAttributes.Builder()
                 .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .setLegacyStreamType(AudioManager.STREAM_NOTIFICATION)
+                .setLegacyStreamType(AudioManager.STREAM_MUSIC)
                 .build()
             player?.setAudioAttributes(attributes)
             player?.prepare()


### PR DESCRIPTION
Set the AudioManager to use Music (media) volume instead of Notification volume

Habitica Username - svenfulen



my Habitica User-ID:
