### PR TITLE
Fix hp display when value is under 1 #1842

### DIFF
--- a/common/src/main/java/com/habitrpg/common/habitica/views/ValueBar.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/views/ValueBar.kt
@@ -184,11 +184,16 @@ class ValueBar(context: Context, attrs: AttributeSet?) : FrameLayout(context, at
             if (animationDuration == 0L || binding.valueTextView.text.isEmpty()) {
                 currentValue = value
             } else {
-                val animator = ValueAnimator.ofInt(currentValue.toInt(), value.toInt())
+                val animator = if (0 < value && value < 1) {
+                    // Show floating points in animation only if the value is between 0 to 1
+                    ValueAnimator.ofFloat(currentValue.toFloat(), value.toFloat())
+                } else {
+                    ValueAnimator.ofInt(currentValue.toInt(), value.toInt())
+                }
                 animator.duration = animationDuration
                 animator.startDelay = animationDelay
                 animator.addUpdateListener {
-                    currentValue = (it.animatedValue as Int).toDouble()
+                    currentValue = (it.animatedValue as? Int)?.toDouble() ?: (it.animatedValue as Float).toDouble()
                     updateBar()
                 }
                 animator.start()


### PR DESCRIPTION
The cause of this issue comes from the ValueAnimator. The under 1 value is truncated due to the cast to int in ValueAnimator. Add animation for floating point values (when value is between 0 ~ 1)

my Habitica User-ID: c6558c97-ff5a-4a3f-8413-c562f907b40f
