### PR TITLE
If no flags loaded, assume character has class selected

### DIFF
--- a/shared/src/commonMain/kotlin/com/habitrpg/shared/habitica/models/Avatar.kt
+++ b/shared/src/commonMain/kotlin/com/habitrpg/shared/habitica/models/Avatar.kt
@@ -27,11 +27,12 @@ interface Avatar {
 
     val hasClass: Boolean
         get() {
-            return preferences?.disableClasses != true && flags?.classSelected == true && stats?.habitClass?.isNotEmpty() == true
+            return preferences?.disableClasses != true && flags?.classSelected ?: true == true && stats?.habitClass?.isNotEmpty() == true
         }
 
     val currentMount: String?
         get() = items?.currentMount ?: ""
+
     val currentPet: String?
         get() = items?.currentPet ?: ""
 


### PR DESCRIPTION
This is for isseu #1846

my Habitica User-ID: ef32aaa4-839b-480c-8218-9b609907d413

**Hello. First, please excuse me if there are any conventions for branch names or commits I didn't follow. I couldn't find a page on it.**

# Analysis of the problem
It seems like flags are only loaded for the current user. This means that when we load a profile page, there are no flags and the hasClass check fails. For the time being I have changed the method to assume true if there are no flags loaded. This displays "warrior" for those who don't have a class, which is behavior that is is consistent with the web version. 
I wasn't sure if this is the right correctio. Because: 
* if we should be loading the flags from the AP, the bug is with the API and not the mobile app
* But if we shouldn't receive flags, would it maybe be better to remove checks to hasClass since the user object assigned warrior, and as far as I can tell functions like one?