### PR TITLE
Fix Task names appearing on incorrect task

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.kt
@@ -485,7 +485,6 @@ open class TaskRecyclerViewFragment : BaseFragment<FragmentRefreshRecyclerviewBi
         super.onResume()
         context?.let { recyclerAdapter?.taskDisplayMode = configManager.taskDisplayMode(it) }
         setInnerAdapter()
-        recyclerAdapter?.filter()
     }
 
     fun setActiveFilter(activeFilter: String) {


### PR DESCRIPTION
Able to reproduce issue consistently - Removed extra unnecessary filter() onResume causing incorrect task placement.

