### PR TITLE
Android 13 Notification Permissions

### DIFF
--- a/Habitica/AndroidManifest.xml
+++ b/Habitica/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".HabiticaApplication"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
@@ -2,6 +2,10 @@ package com.habitrpg.android.habitica.helpers.notifications
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.edit
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.RemoteMessage
@@ -31,6 +35,18 @@ class PushNotificationManager(
 
     fun setUser(user: User) {
         this.user = user
+    }
+
+    /**
+     * New installs on Android 13 require
+     * Notification permissions be approved.
+     * Devices on Android 12L or lower with previously
+     * allowed notification permissions that update to 13
+     * will have notification permissions enabled by default.
+     */
+    fun notificationPermissionEnabled(): Boolean {
+        val notificationManager = NotificationManagerCompat.from(context)
+        return notificationManager.areNotificationsEnabled()
     }
 
     fun addPushDeviceUsingStoredToken() {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
@@ -115,7 +115,13 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
 
     private val notificationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
-    ) { granted -> if (granted) { viewModel.pushNotificationManager.addPushDeviceUsingStoredToken() } }
+    ) { granted ->
+        if (granted) {
+            viewModel.pushNotificationManager.addPushDeviceUsingStoredToken()
+        } else {
+            viewModel.updateAllowPushNotifications(false)
+        }
+    }
 
     val isAppBarExpanded: Boolean
         get() = binding.content.appbar.height - binding.content.appbar.bottom == 0

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/MainActivityViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/MainActivityViewModel.kt
@@ -1,7 +1,9 @@
 package com.habitrpg.android.habitica.ui.viewmodels
 
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.core.content.edit
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.api.MaintenanceApiService
@@ -61,6 +63,7 @@ class MainActivityViewModel : BaseViewModel(), TutorialView.OnTutorialReaction {
                 putString("language", value)
             }
         }
+    var requestNotificationPermission = MutableLiveData(false)
 
     override fun onCleared() {
         taskRepository.close()
@@ -97,7 +100,11 @@ class MainActivityViewModel : BaseViewModel(), TutorialView.OnTutorialReaction {
                     analyticsManager.setUserProperty("checkin_count", user.loginIncentives.toString())
                     analyticsManager.setUserProperty("level", user.stats?.lvl?.toString() ?: "")
                     pushNotificationManager.setUser(user)
-                    pushNotificationManager.addPushDeviceUsingStoredToken()
+                    if (!pushNotificationManager.notificationPermissionEnabled() && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)) {
+                        requestNotificationPermission.value = true
+                    } else {
+                        pushNotificationManager.addPushDeviceUsingStoredToken()
+                    }
                 }
                 contentRepository.retrieveContent()
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/MainActivityViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/MainActivityViewModel.kt
@@ -101,7 +101,9 @@ class MainActivityViewModel : BaseViewModel(), TutorialView.OnTutorialReaction {
                     analyticsManager.setUserProperty("level", user.stats?.lvl?.toString() ?: "")
                     pushNotificationManager.setUser(user)
                     if (!pushNotificationManager.notificationPermissionEnabled() && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)) {
-                        requestNotificationPermission.value = true
+                        if (sharedPreferences.getBoolean("usePushNotifications", true)) {
+                            requestNotificationPermission.value = true
+                        }
                     } else {
                         pushNotificationManager.addPushDeviceUsingStoredToken()
                     }
@@ -112,6 +114,13 @@ class MainActivityViewModel : BaseViewModel(), TutorialView.OnTutorialReaction {
                 userRepository.retrieveTeamPlans()
                     .subscribe({ }, ExceptionHandler.rx())
             )
+        }
+    }
+
+    fun updateAllowPushNotifications(allowPushNotifications: Boolean) {
+        sharedPreferences.getBoolean("usePushNotifications", true)
+        sharedPreferences.edit {
+            putBoolean("usePushNotifications", allowPushNotifications)
         }
     }
 


### PR DESCRIPTION
- Added notification permissions
- Request permission on startup and when enabling push notifications

Permissions are requested only if user currently has not approved notification permission on Android 13.