### PR TITLE
Add google-services.json to wearos/.gitignore

### DIFF
--- a/wearos/.gitignore
+++ b/wearos/.gitignore
@@ -1,1 +1,2 @@
 /build
+google-services.json


### PR DESCRIPTION
I started looking at contributing to the Wear OS app and noticed `google-services.json` isn't included in the .gitignore [despite the README instructing to copy `google-services.json` into both `/Habitica` and `/wearos`.](https://github.com/HabitRPG/habitica-android/blob/67c0978ffca0f3d1e66178b753ba2ff8a8f2fefa/README.md?plain=1#L81)

Since `/wearos` has its own `.gitignore` at `/wearos/.gitignore` I assume we want to use that instead of the root directory `.gitignore`? (or is this just leftover boilerplate?)

Habitica User-ID: 99f20106-7060-4398-b565-26e56c4de2ad but this is such a small change that I don't expect it counting as a contribution
