### PR TITLE
Use LocalDateTime/ZonedDateTime to avoid discrepancy when using Calendar & Gregorian Calendar

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
@@ -105,10 +105,7 @@ class TaskAlarmManager(
             return
         }
 
-        val time = Date.from(zonedTime)
-        val cal = Calendar.getInstance()
-        cal.time = time
-
+        val timeEpochMilli = zonedTime?.toEpochMilli() ?: return
         val intent = Intent(context, TaskReceiver::class.java)
         intent.action = remindersItem.id
         intent.putExtra(TASK_NAME_INTENT_KEY, reminderItemTask.text)
@@ -134,7 +131,7 @@ class TaskAlarmManager(
             withImmutableFlag(PendingIntent.FLAG_CANCEL_CURRENT)
         )
 
-        setAlarm(context, cal.timeInMillis, sender)
+        setAlarm(context, timeEpochMilli, sender)
     }
 
     private fun removeAlarmForRemindersItem(remindersItem: RemindersItem) {

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -25,9 +25,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.TemporalAccessor
-import java.util.Calendar
-import java.util.Date
-import java.util.GregorianCalendar
+import java.util.*
 
 open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
     override val realmClass: Class<Task>
@@ -265,20 +263,22 @@ open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
     fun checkIfDue(): Boolean = isDue == true
 
     fun getNextReminderOccurrence(remindersItem: RemindersItem): ZonedDateTime? {
-        remindersItem.time?.let {
-            val oldTime = it
+        remindersItem.time?.let { oldTime ->
             val now = ZonedDateTime.now().withZoneSameLocal(ZoneId.systemDefault())?.toInstant()
-            val nextDate = nextDue?.firstOrNull()
 
             //If task !isDisplayedActive or if isDisplayedActive but reminder passed,
             //set a updated reminder with nextDate
-            return if (nextDate != null && (!isDisplayedActive || remindersItem.getLocalZonedDateTimeInstant()?.isBefore(now) == true)) {
-                val nextDueCalendar = GregorianCalendar()
-                nextDueCalendar.time = nextDate
-                parse(oldTime)
-                    ?.withYear(nextDueCalendar.get(Calendar.YEAR))
-                    ?.withMonth(nextDueCalendar.get(Calendar.MONTH) + 1) //+1 to handle Gregorian Calendar month range from 0-11
-                    ?.withDayOfMonth(nextDueCalendar.get(Calendar.DAY_OF_MONTH))
+            return if (nextDue?.firstOrNull() != null && (!isDisplayedActive || remindersItem.getLocalZonedDateTimeInstant()?.isBefore(now) == true)) {
+                val nextDate = LocalDateTime.ofInstant(nextDue?.firstOrNull()?.toInstant(), ZoneId.systemDefault())
+                val currentDateTime = LocalDateTime.now()
+                val nextDueCalendar: LocalDateTime = LocalDateTime.of(
+                    currentDateTime.year,
+                    currentDateTime.month,  // Add one to adjust from zero-based counting.
+                    currentDateTime.dayOfMonth,
+                    nextDate.hour,
+                    nextDate.minute
+                )
+                nextDueCalendar.atZone(ZoneId.systemDefault())
             } else {
                 return parse(oldTime)
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -270,11 +270,10 @@ open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
             //set a updated reminder with nextDate
             return if (nextDue?.firstOrNull() != null && (!isDisplayedActive || remindersItem.getLocalZonedDateTimeInstant()?.isBefore(now) == true)) {
                 val nextDate = LocalDateTime.ofInstant(nextDue?.firstOrNull()?.toInstant(), ZoneId.systemDefault())
-                val currentDateTime = LocalDateTime.now()
                 val nextDueCalendar: LocalDateTime = LocalDateTime.of(
-                    currentDateTime.year,
-                    currentDateTime.month,  // Add one to adjust from zero-based counting.
-                    currentDateTime.dayOfMonth,
+                    nextDate.year,
+                    nextDate.month,  // Add one to adjust from zero-based counting.
+                    nextDate.dayOfMonth,
                     nextDate.hour,
                     nextDate.minute
                 )


### PR DESCRIPTION
A Calendar instance is created with the current time, and a GregorianCalendar was used to set the Day, Month, and Year of a updated reminder.

If the reminders were updated afternoon (say - 2PM), the Calendar would pass a hour value of 14. The Gregorian Calendar would take that value not as 2PM but as an hour over 12 which overflows into AM of the following day - causing a loop of reiterating days not scheduled during the original alarm/reminder creation.

This would not occur if the alarms were updated/set in the morning, which is why the issue seemed inconsistent.

The current Date object is now being updated to a LocalDateTime.