### PR TITLE
Fix Zero-width space was added/saved and being accounted for when discard modal pops up.

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import android.text.Spanned
 import com.google.gson.annotations.SerializedName
 import com.habitrpg.android.habitica.R
+import com.habitrpg.android.habitica.extensions.removeZeroWidthSpace
 import com.habitrpg.android.habitica.helpers.ExceptionHandler
 import com.habitrpg.android.habitica.models.BaseMainObject
 import com.habitrpg.android.habitica.models.Tag
@@ -355,10 +356,10 @@ open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
     }
 
     fun isBeingEdited(task: Task): Boolean {
-
+        
         when {
             text != task.text -> return true
-            notes != task.notes -> return true
+            notes != task.notes?.removeZeroWidthSpace() -> return true
             reminders?.size != task.reminders?.size -> return true
             checklist?.size != task.checklist?.size -> return true
             reminders?.mapIndexed { index, remindersItem -> task.reminders?.get(index) != remindersItem }?.contains(true) == true -> return true

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.kt
@@ -42,6 +42,8 @@ import com.habitrpg.android.habitica.data.TaskRepository
 import com.habitrpg.android.habitica.databinding.ActivityTaskFormBinding
 import com.habitrpg.android.habitica.extensions.OnChangeTextWatcher
 import com.habitrpg.android.habitica.extensions.addCancelButton
+import com.habitrpg.android.habitica.extensions.addZeroWidthSpace
+import com.habitrpg.android.habitica.extensions.removeZeroWidthSpace
 import com.habitrpg.android.habitica.helpers.ExceptionHandler
 import com.habitrpg.android.habitica.helpers.TaskAlarmManager
 import com.habitrpg.android.habitica.helpers.launchCatching
@@ -509,12 +511,7 @@ class TaskFormActivity : BaseActivity() {
         }
         canSave = true
         binding.textEditText.setText(task.text)
-        val spannable: Spannable = SpannableString(task.notes)
-        Linkify.addLinks(spannable, Linkify.WEB_URLS)
-        //Append a zero-width space to the Spannable to allow clicking
-        //on the open spaces (and prevent links from opening)
-        val text: CharSequence = TextUtils.concat(spannable, "\u200B")
-        binding.notesEditText.setText(text)
+        binding.notesEditText.setText(task.notes?.addZeroWidthSpace())
         viewModel.taskDifficulty.value = TaskDifficulty.valueOf(task.priority)
         when (taskType) {
             TaskType.HABIT -> {
@@ -593,7 +590,7 @@ class TaskFormActivity : BaseActivity() {
         thisTask.dateCreated = Date()
 
         thisTask.text = binding.textEditText.text.toString()
-        thisTask.notes = binding.notesEditText.text.toString()
+        thisTask.notes = binding.notesEditText.text.toString().removeZeroWidthSpace()
         thisTask.priority = viewModel.taskDifficulty.value.value
         if (usesTaskAttributeStats) {
             thisTask.attribute = viewModel.selectedAttribute.value

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.databinding.TaskFormChecklistItemBinding
 import com.habitrpg.android.habitica.extensions.OnChangeTextWatcher
+import com.habitrpg.android.habitica.extensions.addZeroWidthSpace
 import com.habitrpg.android.habitica.models.tasks.ChecklistItem
 import com.habitrpg.common.habitica.extensions.dpToPx
 import com.habitrpg.common.habitica.extensions.getThemeColor
@@ -35,12 +36,9 @@ class ChecklistItemFormView @JvmOverloads constructor(
     var item: ChecklistItem = ChecklistItem()
         set(value) {
             field = value
-            val spannable: Spannable = SpannableString(item.text)
-            Linkify.addLinks(spannable, Linkify.WEB_URLS)
             //Append a zero-width space to the Spannable to allow clicking
             //on the open spaces (and prevent the link from opening)
-            val text: CharSequence = TextUtils.concat(spannable, "\u200B")
-            binding.editText.setText(text)
+            binding.editText.setText(item.text?.addZeroWidthSpace())
         }
 
     var tintColor: Int = context.getThemeColor(R.attr.taskFormTint)

--- a/common/src/main/java/com/habitrpg/common/habitica/extensions/String-Extensions.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/extensions/String-Extensions.kt
@@ -1,6 +1,10 @@
 package com.habitrpg.android.habitica.extensions
 
 import android.text.Html
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.TextUtils
+import android.text.util.Linkify
 import java.util.Locale
 
 fun String.fromHtml(): CharSequence {
@@ -10,6 +14,18 @@ fun String.fromHtml(): CharSequence {
         @Suppress("DEPRECATION")
         Html.fromHtml(this)
     }
+}
+
+fun String.addZeroWidthSpace(): CharSequence {
+    val spannable: Spannable = SpannableString(this)
+    Linkify.addLinks(spannable, Linkify.WEB_URLS)
+    //Append a zero-width space to the Spannable to allow clicking
+    //on the open spaces (and prevent the link from opening)
+    return TextUtils.concat(spannable, "\u200B")
+}
+
+fun String.removeZeroWidthSpace(): String {
+    return this.replace("\u200B", "")
 }
 
 fun String.localizedCapitalize(): String {


### PR DESCRIPTION
Added extensions for adding/removing zero width spaces, remove any unnecessary zero-width spaces when saving or discarding tasks.