### PR TITLE
Revert ability to click on link while editing tasks.

### DIFF
--- a/Habitica/res/layout/checklist_item_row.xml
+++ b/Habitica/res/layout/checklist_item_row.xml
@@ -30,7 +30,7 @@
     <com.habitrpg.android.habitica.ui.views.EllipsisTextView
         android:id="@+id/checkedTextView"
         style="@style/Body2"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="5dp"
         android:paddingStart="16dp"

--- a/Habitica/res/layout/task_main_content.xml
+++ b/Habitica/res/layout/task_main_content.xml
@@ -37,7 +37,7 @@
         <com.habitrpg.android.habitica.ui.views.EllipsisTextView
             android:id="@+id/notesTextView"
             style="@style/Caption2.Regular"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/text_ternary"
             android:maxLines="3"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ChecklistItemFormView.kt
@@ -18,7 +18,6 @@ import androidx.core.content.ContextCompat
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.databinding.TaskFormChecklistItemBinding
 import com.habitrpg.android.habitica.extensions.OnChangeTextWatcher
-import com.habitrpg.android.habitica.extensions.addZeroWidthSpace
 import com.habitrpg.android.habitica.models.tasks.ChecklistItem
 import com.habitrpg.common.habitica.extensions.dpToPx
 import com.habitrpg.common.habitica.extensions.getThemeColor
@@ -36,9 +35,6 @@ class ChecklistItemFormView @JvmOverloads constructor(
     var item: ChecklistItem = ChecklistItem()
         set(value) {
             field = value
-            //Append a zero-width space to the Spannable to allow clicking
-            //on the open spaces (and prevent the link from opening)
-            binding.editText.setText(item.text?.addZeroWidthSpace())
         }
 
     var tintColor: Int = context.getThemeColor(R.attr.taskFormTint)
@@ -97,8 +93,6 @@ class ChecklistItemFormView @JvmOverloads constructor(
         // a plus button we set it as 'unimportant for accessibility' so it can't be focused.
         binding.button.contentDescription = context.getString(R.string.delete_checklist_entry)
         binding.button.drawable.mutate().setTint(tintColor)
-        binding.editText.movementMethod = LinkMovementMethod.getInstance()
-
         binding.editText.addTextChangedListener(
             OnChangeTextWatcher { s, _, _, _ ->
                 item.text = s.toString()


### PR DESCRIPTION
Revert ability to click on link while editing tasks.
Task texts (Checklists, notes) using wrap_content to avoid clicking on link if clicking outside of text