### PR TITLE
Fix user self-block in FullProfileActivity

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
@@ -1,6 +1,7 @@
 package com.habitrpg.android.habitica.ui.activities
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.graphics.Typeface
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
@@ -58,6 +59,8 @@ class FullProfileActivity : BaseActivity() {
     lateinit var apiClient: ApiClient
     @Inject
     lateinit var socialRepository: SocialRepository
+    @Inject
+    lateinit var sharedPrefs: SharedPreferences
 
     private var userID = ""
     private var username: String? = null
@@ -120,12 +123,19 @@ class FullProfileActivity : BaseActivity() {
         val inflater = menuInflater
         inflater.inflate(R.menu.menu_full_profile, menu)
         val item = menu.findItem(R.id.block_user)
+
+        if (isMyProfile()) item.isVisible = false
+
         if (isUserBlocked()) {
             item?.title = getString(R.string.unblock_user)
         } else {
             item?.title = getString(R.string.block)
         }
         return super.onCreateOptionsMenu(menu)
+    }
+
+    private fun isMyProfile(): Boolean {
+        return sharedPrefs.getString("UserID", "") == userID
     }
 
     private fun isUserBlocked(): Boolean {


### PR DESCRIPTION
Fix #1873
As mentioned in the issue, When the profile is logged-in user's profile, the block menu item is hidden.

my Habitica User-ID : cdae7176-0d4b-41c5-9ca5-620dc9efa36d


## Before

<img src="https://user-images.githubusercontent.com/39683194/212020922-fb36fcc8-302b-41bd-a3e7-65709060339d.png" width="50%" height="50%" />

## After

<img src="https://user-images.githubusercontent.com/39683194/212020735-44cf8996-7b38-44ac-986e-9764f6e5c72e.png" width="50%" height="50%" />


