### PR TITLE
Handle different Locale when formatting 

### DIFF
--- a/common/src/main/java/com/habitrpg/common/habitica/helpers/NumberAbbreviator.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/helpers/NumberAbbreviator.kt
@@ -23,7 +23,9 @@ object NumberAbbreviator {
         if (decimalCount > 0) {
             pattern = ("$pattern.").padEnd(4 + decimalCount, '#')
         }
-        val formatter = DecimalFormat(pattern + abbreviationForCounter(context, counter).replace(".", ""))
+        val formatter = DecimalFormat(pattern + abbreviationForCounter(context, counter)
+            .replace(".", "")
+            .replace(",", ""))
         formatter.roundingMode = RoundingMode.FLOOR
         return formatter.format(usedNumber)
     }


### PR DESCRIPTION
(ex: 26353,394 instead of 26353.394, which may eventually cause a ANR when formatting)