### PR TITLE
Remove setting animalType as title (overwrites text using base text)

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
@@ -141,11 +141,6 @@ class PetDetailRecyclerFragment :
         view.post { setGridSpanCount(view.width) }
     }
 
-    override fun onResume() {
-        super.onResume()
-        activity?.title = animalType
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putString(ANIMAL_TYPE_KEY, this.animalType)


### PR DESCRIPTION
Example: Bear Cub was getting reverted to animalType as BearCub