### PR TITLE
Update text -> Capitalize and add spaces

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/inventory/ItemRecyclerAdapter.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/adapter/inventory/ItemRecyclerAdapter.kt
@@ -24,6 +24,7 @@ import com.habitrpg.android.habitica.ui.menu.BottomSheetMenuItem
 import com.habitrpg.android.habitica.ui.views.dialogs.DetailDialog
 import com.habitrpg.common.habitica.extensions.layoutInflater
 import com.habitrpg.common.habitica.extensions.loadImage
+import com.habitrpg.common.habitica.extensions.localizedCapitalizeWithSpaces
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -95,7 +96,7 @@ class ItemRecyclerAdapter(val context: Context) : BaseRecyclerViewAdapter<OwnedI
         fun bind(ownedItem: OwnedItem, item: Item?) {
             this.ownedItem = ownedItem
             this.item = item
-            binding.titleTextView.text = item?.text ?: ownedItem.key
+            binding.titleTextView.text = item?.text ?: ownedItem.key?.localizedCapitalizeWithSpaces()
             binding.ownedTextView.text = ownedItem.numberOwned.toString()
 
             val disabled = if (isHatching) {

--- a/common/src/main/java/com/habitrpg/common/habitica/extensions/String-Extensions.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/extensions/String-Extensions.kt
@@ -5,7 +5,7 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.util.Linkify
-import java.util.Locale
+import java.util.*
 
 fun String.fromHtml(): CharSequence {
     return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
@@ -31,3 +31,12 @@ fun String.removeZeroWidthSpace(): String {
 fun String.localizedCapitalize(): String {
     return this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 }
+
+fun String.spaceBetweenCapitals(): String {
+    return this.replace("(.)([A-Z0-9]\\w)".toRegex(), "$1 $2")
+}
+
+fun String.localizedCapitalizeWithSpaces(): String {
+    return this.localizedCapitalize().spaceBetweenCapitals()
+}
+


### PR DESCRIPTION
This is pretty quick-fix-esque but allows us to properly format the text without having to use the Skill object text immediately