### PR TITLE
Android 9 Gradient Fix

### DIFF
--- a/Habitica/res/drawable/no_party_background_gradient.xml
+++ b/Habitica/res/drawable/no_party_background_gradient.xml
@@ -3,8 +3,8 @@
     <gradient
         android:angle="90"
         android:startColor="?attr/colorContentBackground"
-        android:centerColor="@color/transparent"
-        android:endColor="@color/transparent"
+        android:centerColor="?attr/colorGradientTransparentBackground"
+        android:endColor="?attr/colorGradientTransparentBackground"
         android:type="linear"
         android:centerX="0.6"/>
 </shape>

--- a/Habitica/res/values/attrs.xml
+++ b/Habitica/res/values/attrs.xml
@@ -7,6 +7,7 @@
     <attr name="colorTintedBackgroundOffset" format="color" />
     <attr name="colorContentBackgroundOffset" format="color" />
     <attr name="colorWindowBackground" format="color" />
+    <attr name="colorGradientTransparentBackground" format="color" />
     <attr name="textColorPrimary" format="color" />
     <attr name="textColorSecondary" format="color" />
     <attr name="textColorTintedPrimary" format="color" />

--- a/Habitica/res/values/styles.xml
+++ b/Habitica/res/values/styles.xml
@@ -40,6 +40,7 @@
         <item name="colorContentBackgroundOffset">@color/content_background_offset</item>
         <item name="colorWindowBackground">@color/window_background</item>
         <item name="colorTintedBackground">@color/brand_800</item>
+        <item name="colorGradientTransparentBackground">@color/transparent</item>
         <item name="colorTintedBackgroundOffset">@color/brand_50012</item>
         <item name="textColorTintedSecondary">@color/brand_sub_text</item>
         <item name="textColorTintedPrimary">@color/brand_100</item>


### PR DESCRIPTION
Android 9 gradients play well with setting colors using all color resources OR attr, using both causes a crash.