### PR TITLE
Manual reschedule alarm updates - use cases around manually rescheduling an alarm

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/ZonedDate-Extensions.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/ZonedDate-Extensions.kt
@@ -1,0 +1,38 @@
+package com.habitrpg.android.habitica.extensions
+
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.TextStyle
+import java.time.temporal.TemporalAccessor
+import java.util.Locale
+
+fun String.parseToZonedDateTime(): ZonedDateTime? {
+    val parsed: TemporalAccessor = formatter().parseBest(
+        this,
+        ZonedDateTime::from, LocalDateTime::from
+    )
+    return if (parsed is ZonedDateTime) {
+        parsed
+    } else {
+        val defaultZone: ZoneId = ZoneId.of("UTC")
+        (parsed as LocalDateTime).atZone(defaultZone)
+    }
+}
+
+/**
+ * Returns full display name in default Locale (Monday, Tuesday, Wednesday, etc.)
+ */
+fun ZonedDateTime.dayOfWeekString(): String {
+    return DayOfWeek.from(this).getDisplayName(TextStyle.FULL, Locale.getDefault())
+}
+
+fun formatter(): DateTimeFormatter =
+    DateTimeFormatterBuilder().append(DateTimeFormatter.ISO_LOCAL_DATE)
+        .appendPattern("['T'][' ']")
+        .append(DateTimeFormatter.ISO_LOCAL_TIME)
+        .appendPattern("[XX]")
+        .toFormatter()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
@@ -81,10 +81,8 @@ class TaskAlarmManager(
     }
 
     private fun setTimeForDailyReminder(remindersItem: RemindersItem?, task: Task): RemindersItem? {
-        val newTime = (remindersItem?.let { task.getNextReminderOccurrence(it) } ?: return null)
-
-        remindersItem.time = newTime.withZoneSameLocal(ZoneId.systemDefault())
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        val newTime = task.getNextReminderOccurrence(remindersItem, context)
+        remindersItem?.time = newTime?.withZoneSameLocal(ZoneId.systemDefault())?.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
         return remindersItem
     }


### PR DESCRIPTION
When manually changing the alarm time, nextDue will provide the previously set upcoming alarm - however if the alarm was changed to a upcoming time today (and not before the current time) AND the previous alarm set for today already passed, we want to check if the alarm repeat/days includes today as well. If so - use today's date to schedule an alarm. If not, use nextDue

Alarms automatically rescheduled -> nextDue used.
A alarm that already passed today and is rescheduled for a upcoming time today -> Schedule for today (instead of using nextDue)

- Update reschedule alarm to handle some use cases around user rescheduling alarm
- Zoned Time extension