### PR TITLE
Adjust due date display for to-dos

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/ZonedDate-Extensions.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/ZonedDate-Extensions.kt
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.TextStyle
 import java.time.temporal.TemporalAccessor
+import java.util.Date
 import java.util.Locale
 
 fun String.parseToZonedDateTime(): ZonedDateTime? {
@@ -21,6 +22,10 @@ fun String.parseToZonedDateTime(): ZonedDateTime? {
         val defaultZone: ZoneId = ZoneId.of("UTC")
         (parsed as LocalDateTime).atZone(defaultZone)
     }
+}
+
+fun Date.toZonedDateTime(): ZonedDateTime? {
+    return this.toInstant().atZone(ZoneId.systemDefault())
 }
 
 /**

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -153,8 +153,6 @@ open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
         if (zonedDueDate != null) {
             val day = ZonedDateTime.now().dayOfYear
             val year = ZonedDateTime.now().year
-            val test1 = zonedDueDate.dayOfYear
-            val test2 = zonedDueDate.year
             return (zonedDueDate.dayOfYear == day) && (zonedDueDate.year == year)
         }
         return null

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/tasks/Task.kt
@@ -8,6 +8,7 @@ import com.google.gson.annotations.SerializedName
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.extensions.dayOfWeekString
 import com.habitrpg.android.habitica.extensions.parseToZonedDateTime
+import com.habitrpg.android.habitica.extensions.toZonedDateTime
 import com.habitrpg.android.habitica.models.BaseMainObject
 import com.habitrpg.android.habitica.models.Tag
 import com.habitrpg.common.habitica.helpers.ExceptionHandler
@@ -22,6 +23,7 @@ import io.realm.annotations.Ignore
 import io.realm.annotations.PrimaryKey
 import org.json.JSONArray
 import org.json.JSONException
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -144,6 +146,23 @@ open class Task : RealmObject, BaseMainObject, Parcelable, BaseTask {
     fun isDisplayedActiveForUser(userID: String?): Boolean {
         val isActive = ((isDue == true && type == TaskType.DAILY) || type == TaskType.TODO)
         return isActive && !completed(userID)
+    }
+
+    fun isDueToday(): Boolean? {
+        val zonedDueDate = dueDate?.toZonedDateTime()
+        if (zonedDueDate != null) {
+            val day = ZonedDateTime.now().dayOfYear
+            val year = ZonedDateTime.now().year
+            val test1 = zonedDueDate.dayOfYear
+            val test2 = zonedDueDate.year
+            return (zonedDueDate.dayOfYear == day) && (zonedDueDate.year == year)
+        }
+        return null
+    }
+
+    fun isDayOrMorePastDue(): Boolean? {
+        val zonedDueDate = dueDate?.toZonedDateTime()
+        return zonedDueDate?.toLocalDate()?.isBefore(LocalDate.now())
     }
 
     val streakString: String?

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/tasks/TodoViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/tasks/TodoViewHolder.kt
@@ -1,6 +1,8 @@
 package com.habitrpg.android.habitica.ui.viewHolders.tasks
 
 import android.view.View
+import androidx.core.content.ContextCompat
+import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.helpers.GroupPlanInfoProvider
 import com.habitrpg.android.habitica.models.tasks.ChecklistItem
 import com.habitrpg.android.habitica.models.tasks.Task
@@ -34,7 +36,14 @@ class TodoViewHolder(
     override fun configureSpecialTaskTextView(task: Task) {
         super.configureSpecialTaskTextView(task)
         if (task.dueDate != null) {
-            task.dueDate?.let { specialTaskTextView?.text = dateFormatter.format(it) }
+            if (task.isDueToday() == true) {
+                specialTaskTextView?.text = context.getString(R.string.today)
+            } else if (task.isDayOrMorePastDue() == true) {
+                task.dueDate?.let { specialTaskTextView?.text = dateFormatter.format(it) }
+                specialTaskTextView?.setTextColor(ContextCompat.getColor(context, R.color.maroon_100))
+            } else {
+                task.dueDate?.let { specialTaskTextView?.text = dateFormatter.format(it) }
+            }
             this.specialTaskTextView?.visibility = View.VISIBLE
             calendarIconView?.visibility = View.VISIBLE
         } else {


### PR DESCRIPTION
Due date update to reflect if to-do is today (Shown as "Today", in the future with local date preference, or due yesterday or longer shown with red/maroon text)