### PR TITLE
Fix IndeterminateProgressView not removing (WearOS)

### DIFF
--- a/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/activities/BaseActivity.kt
+++ b/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/activities/BaseActivity.kt
@@ -76,11 +76,12 @@ abstract class BaseActivity<B : ViewBinding, VM : BaseViewModel> : ComponentActi
 
     fun stopAnimatingProgress() {
         if (progressView != null) {
-            progressView?.stopAnimation()
-            progressView?.post {
-                wrapperBinding.root.removeView(progressView)
+            progressView?.stopAnimation {
+                progressView?.post {
+                    wrapperBinding.root.removeView(progressView)
+                    progressView = null
+                }
             }
-            progressView = null
         } else {
             wrapperBinding.root.children.forEach {
                 if (it is IndeterminateProgressView) {


### PR DESCRIPTION
There was a bug where `wrapperBinding.root.removeView(progressView)` was always evaluating `progressView` as `null`, so the IndeterminateProgressView was never actually being removed from the ViewGroup.

Even though the `progressView = null` assignment happens on line 84 and `...removeView(progressView)` gets invoked on line 82, `...removeView(progressView)` is invoked inside `progressView?.post { ... }`, [meaning it gets scheduled on the UI thread and doesn't actually evaluate `progressView` until after the `progressView = null` reassignment.](https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#8693) This PR moves the `progressView = null` assignment inside the UI runnable after the `...removeView(progressView)` invocation.

<img width="755" alt="image" src="https://user-images.githubusercontent.com/22078613/231323784-f33e593f-845e-4515-b012-31016614ec14.png">

---

This PR also mimics the smooth ease-in animation when the progress bar completes. If this was not added, the progress bar would smoothly reveal itself then abruptly disappear (see second video). Now, the progress bar smoothly reveals itself then smoothly disappears (see third video).

---
| Current Behavior | Without Ease-Out | With Ease-Out |
|--------|--------|--------|
| <video src="https://user-images.githubusercontent.com/22078613/231326579-f2aa16ce-83fa-4bae-8a35-61790a701b3d.mov"> | <video src="https://user-images.githubusercontent.com/22078613/231326979-3ff38632-2b06-455d-80e6-90e042f97667.mov"> | <video src="https://user-images.githubusercontent.com/22078613/231326987-38cb879d-66cb-4308-a126-6b2cc4edd9e4.mov"> |

---

My Habitica User-ID: 99f20106-7060-4398-b565-26e56c4de2ad