### PR TITLE
Fix Party Chat

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
@@ -40,7 +40,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 @AndroidEntryPoint
-class ChatFragment : BaseFragment<FragmentChatBinding>() {
+class ChatFragment(var groupViewModel: GroupViewModel? = null) : BaseFragment<FragmentChatBinding>() {
 
     override var binding : FragmentChatBinding? = null
 
@@ -51,9 +51,15 @@ class ChatFragment : BaseFragment<FragmentChatBinding>() {
         return FragmentChatBinding.inflate(inflater, container, false)
     }
 
-    val viewModel: GroupViewModel by viewModels(
-        ownerProducer = { parentFragment as Fragment }
-    )
+    // In instances where ChatFragment is created from FragmentStateAdapter,
+    // use a passed viewmodel reference.Else, use the Parent fragment as the ownerProducer.
+    val viewModel: GroupViewModel
+        get() {
+            groupViewModel?.let { return it }
+            return parentViewModel
+        }
+
+    private val parentViewModel: GroupViewModel by viewModels(ownerProducer = { parentFragment as Fragment })
 
     @Inject
     lateinit var configManager : AppConfigManager

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/party/PartyFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/party/PartyFragment.kt
@@ -190,7 +190,7 @@ class PartyFragment : BaseMainFragment<FragmentViewpagerBinding>() {
                         detailFragment
                     }
                     1 -> {
-                        ChatFragment()
+                        ChatFragment(viewModel)
                     }
                     else -> Fragment()
                 } ?: Fragment()


### PR DESCRIPTION
I believe when creating a new fragment instance using FragmentStateAdapter, the parentFragment is not PartyFragment due to how FragmentStateAdapter manages it's fragments internally. 

In instances where ChatFragment is created from FragmentStateAdapter, use a passed viewmodel reference.Else, use the Parent fragment as the ownerProducer.