### PR TITLE
Fix duplicate in-app notification views

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
@@ -141,7 +141,11 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
                 }
 
                 if (item != null) {
-                    binding.notificationItems.addView(item)
+                    item.tag = it.id
+                    
+                    if (binding.notificationItems.findViewWithTag<View>(it.id) == null) {
+                        binding.notificationItems.addView(item)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Assign tag to view using Notification ID, and check if the view tag already exists.