### PR TITLE
Review Manager - In App Review

### DIFF
--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-themeadapter-material:$accompanist_version"
     implementation "androidx.compose.material3:material3:1.1.1"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
+    implementation 'com.google.android.play:core:1.10.0'
 
     implementation 'androidx.activity:activity-compose:1.7.2'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
@@ -12,19 +12,19 @@ class ReviewManager(private val context: Context) {
     companion object {
         private const val REVIEW_REQUEST_COUNT_KEY = "ReviewRequestCount"
         private const val INITIAL_CHECKINS_KEY = "InitialCheckins"
-        private const val REVIEW_REQUESTED = "ReviewRequested"
+        private const val SHOULD_QUEUE_REVIEW = "ShouldQueueReview"
         private const val LAST_REVIEW_CHECKIN_KEY = "LastReviewCheckin"
     }
 
     private fun canRequestReview(currentCheckins: Int): Boolean {
         val initialCheckins = sharedPref.getInt(INITIAL_CHECKINS_KEY, -1)
-        val reviewRequested = sharedPref.getBoolean(REVIEW_REQUESTED, false)
+        val shouldQueueReview = sharedPref.getBoolean(SHOULD_QUEUE_REVIEW, false)
         val lastReviewCheckin = sharedPref.getInt(LAST_REVIEW_CHECKIN_KEY, -1)
 
-        if (reviewRequested) {
+        if (!shouldQueueReview) {
             // First review request has been made, wait for following request (if any)
             // to request again in the spirit of asking during a logical break.
-            sharedPref.edit().putBoolean(REVIEW_REQUESTED, true).apply()
+            sharedPref.edit().putBoolean(SHOULD_QUEUE_REVIEW, true).apply()
             return false
         }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
@@ -1,0 +1,34 @@
+package com.habitrpg.android.habitica.helpers
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.play.core.review.ReviewManagerFactory
+
+class ReviewManager(private val context: Context) {
+
+    private val reviewManager = ReviewManagerFactory.create(context)
+    private val sharedPref = context.getSharedPreferences("ReviewPrefs", Context.MODE_PRIVATE)
+
+    fun hasShownReviewForEvent(eventKey: String): Boolean {
+        return sharedPref.getBoolean(eventKey, false)
+    }
+
+    fun setReviewShownForEvent(eventKey: String) {
+        sharedPref.edit().putBoolean(eventKey, true).apply()
+    }
+
+    fun requestReview(activity: AppCompatActivity) {
+        val request = reviewManager.requestReviewFlow()
+        request.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val reviewInfo = task.result
+                val flow = reviewManager.launchReviewFlow(activity, reviewInfo)
+                flow.addOnCompleteListener { _ ->
+                    // The flow has finished. The API does not indicate whether the user
+                    // reviewed or not, or even whether the review dialog was shown. Thus, no
+                    // matter the result, we assume that the user has gone through the review flow.
+                }
+            }
+        }
+    }
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
@@ -9,26 +9,73 @@ class ReviewManager(private val context: Context) {
     private val reviewManager = ReviewManagerFactory.create(context)
     private val sharedPref = context.getSharedPreferences("ReviewPrefs", Context.MODE_PRIVATE)
 
-    fun hasShownReviewForEvent(eventKey: String): Boolean {
-        return sharedPref.getBoolean(eventKey, false)
+    companion object {
+        private const val REVIEW_REQUEST_COUNT_KEY = "ReviewRequestCount"
+        private const val INITIAL_CHECKINS_KEY = "InitialCheckins"
+        private const val REVIEW_REQUESTED = "ReviewRequested"
+        private const val LAST_REVIEW_CHECKIN_KEY = "LastReviewCheckin"
     }
 
-    fun setReviewShownForEvent(eventKey: String) {
-        sharedPref.edit().putBoolean(eventKey, true).apply()
+    private fun canRequestReview(currentCheckins: Int): Boolean {
+        val initialCheckins = sharedPref.getInt(INITIAL_CHECKINS_KEY, -1)
+        val reviewRequested = sharedPref.getBoolean(REVIEW_REQUESTED, false)
+        val lastReviewCheckin = sharedPref.getInt(LAST_REVIEW_CHECKIN_KEY, -1)
+
+        if (reviewRequested) {
+            // First review request has been made, wait for following request (if any)
+            // to request again in the spirit of asking during a logical break.
+            sharedPref.edit().putBoolean(REVIEW_REQUESTED, true).apply()
+            return false
+        }
+
+        if (initialCheckins == -1) {
+            // Store the current checkins as the initial value
+            sharedPref.edit().putInt(INITIAL_CHECKINS_KEY, currentCheckins).apply()
+            return true
+        }
+
+        val requestCount = sharedPref.getInt(REVIEW_REQUEST_COUNT_KEY, 0)
+
+        if (requestCount >= 5) {
+            // Requested reviews 5 times already, no longer request in-app review
+            return false
+        }
+
+        if (currentCheckins - initialCheckins > 75) {
+            // Player has more than 75 additional check-ins starting from the first request, no longer request in-app review
+            return false
+        }
+
+        if (lastReviewCheckin != -1 && currentCheckins - lastReviewCheckin < 5) {
+            // Less than 5 check-ins since the last review request, wait for more check-ins
+            return false
+        }
+
+        return true
     }
 
-    fun requestReview(activity: AppCompatActivity) {
+    fun requestReview(activity: AppCompatActivity, currentCheckins: Int) {
+        if (!canRequestReview(currentCheckins)) return
+
         val request = reviewManager.requestReviewFlow()
         request.addOnCompleteListener { task ->
             if (task.isSuccessful) {
                 val reviewInfo = task.result
                 val flow = reviewManager.launchReviewFlow(activity, reviewInfo)
                 flow.addOnCompleteListener { _ ->
-                    // The flow has finished. The API does not indicate whether the user
-                    // reviewed or not, or even whether the review dialog was shown. Thus, no
-                    // matter the result, we assume that the user has gone through the review flow.
+                    // The flow has finished - Increase the request count.
+                    incrementReviewRequestCount()
                 }
             }
         }
+
+        // Save the current checkins after a successful review request
+        sharedPref.edit().putInt(LAST_REVIEW_CHECKIN_KEY, currentCheckins).apply()
+    }
+
+    private fun incrementReviewRequestCount() {
+        val currentCount = sharedPref.getInt(REVIEW_REQUEST_COUNT_KEY, 0)
+        sharedPref.edit().putInt(REVIEW_REQUEST_COUNT_KEY, currentCount + 1).apply()
     }
 }
+

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/ReviewManager.kt
@@ -2,6 +2,7 @@ package com.habitrpg.android.habitica.helpers
 
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
 import com.google.android.play.core.review.ReviewManagerFactory
 
 class ReviewManager(private val context: Context) {
@@ -24,13 +25,17 @@ class ReviewManager(private val context: Context) {
         if (!shouldQueueReview) {
             // First review request has been made, wait for following request (if any)
             // to request again in the spirit of asking during a logical break.
-            sharedPref.edit().putBoolean(SHOULD_QUEUE_REVIEW, true).apply()
-            return false
+            sharedPref.edit {
+                putBoolean(SHOULD_QUEUE_REVIEW, true)
+            }
         }
 
         if (initialCheckins == -1) {
             // Store the current checkins as the initial value
-            sharedPref.edit().putInt(INITIAL_CHECKINS_KEY, currentCheckins).apply()
+
+            sharedPref.edit {
+                putInt(INITIAL_CHECKINS_KEY, currentCheckins)
+            }
             return true
         }
 
@@ -70,12 +75,16 @@ class ReviewManager(private val context: Context) {
         }
 
         // Save the current checkins after a successful review request
-        sharedPref.edit().putInt(LAST_REVIEW_CHECKIN_KEY, currentCheckins).apply()
+        sharedPref.edit {
+            putInt(LAST_REVIEW_CHECKIN_KEY, currentCheckins)
+        }
     }
 
     private fun incrementReviewRequestCount() {
         val currentCount = sharedPref.getInt(REVIEW_REQUEST_COUNT_KEY, 0)
-        sharedPref.edit().putInt(REVIEW_REQUEST_COUNT_KEY, currentCount + 1).apply()
+        sharedPref.edit {
+            putInt(REVIEW_REQUEST_COUNT_KEY, currentCount + 1)
+        }
     }
 }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/modules/AppModule.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/modules/AppModule.kt
@@ -8,6 +8,7 @@ import com.habitrpg.android.habitica.BuildConfig
 import com.habitrpg.android.habitica.data.ApiClient
 import com.habitrpg.android.habitica.data.ContentRepository
 import com.habitrpg.android.habitica.helpers.AppConfigManager
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.android.habitica.helpers.SoundFileLoader
 import com.habitrpg.android.habitica.helpers.notifications.PushNotificationManager
 import com.habitrpg.common.habitica.helpers.KeyHelper
@@ -99,5 +100,10 @@ class AppModule {
     @Singleton
     fun providesRemoteConfigManager(contentRepository: ContentRepository?): AppConfigManager {
         return AppConfigManager(contentRepository)
+    }
+
+    @Provides
+    fun providesReviewManager(@ApplicationContext context: Context): ReviewManager {
+        return ReviewManager(context)
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
@@ -15,6 +15,7 @@ import com.habitrpg.android.habitica.databinding.ActivityArmoireBinding
 import com.habitrpg.android.habitica.helpers.AdHandler
 import com.habitrpg.android.habitica.helpers.AdType
 import com.habitrpg.android.habitica.helpers.AppConfigManager
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.android.habitica.ui.viewmodels.MainUserViewModel
 import com.habitrpg.android.habitica.ui.views.ads.AdButton
 import com.habitrpg.android.habitica.ui.views.dialogs.HabiticaBottomSheetDialog
@@ -47,6 +48,7 @@ class ArmoireActivity : BaseActivity() {
 
     @Inject
     lateinit var userViewModel: MainUserViewModel
+    private lateinit var reviewManager: ReviewManager
 
     override fun getLayoutResId(): Int = R.layout.activity_armoire
 
@@ -57,6 +59,7 @@ class ArmoireActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        reviewManager = ReviewManager(this)
 
         binding.goldView.currency = "gold"
         binding.goldView.animationDuration = 1000
@@ -72,6 +75,11 @@ class ArmoireActivity : BaseActivity() {
                 val remaining = inventoryRepository.getArmoireRemainingCount().firstOrNull() ?: 0
                 binding.equipmentCountView.text = getString(R.string.equipment_remaining, remaining)
                 binding.noEquipmentView.visibility = if (remaining > 0) View.GONE else View.VISIBLE
+
+                val totalCheckIns = user?.loginIncentives
+                if (remaining > 0 && totalCheckIns != null) {
+                    reviewManager.requestReview(this@ArmoireActivity, totalCheckIns)
+                }
             }
         }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.databinding.ActivityArmoireBinding
+import com.habitrpg.android.habitica.extensions.observeOnce
 import com.habitrpg.android.habitica.helpers.AdHandler
 import com.habitrpg.android.habitica.helpers.AdType
 import com.habitrpg.android.habitica.helpers.AppConfigManager
@@ -75,11 +76,6 @@ class ArmoireActivity : BaseActivity() {
                 val remaining = inventoryRepository.getArmoireRemainingCount().firstOrNull() ?: 0
                 binding.equipmentCountView.text = getString(R.string.equipment_remaining, remaining)
                 binding.noEquipmentView.visibility = if (remaining > 0) View.GONE else View.VISIBLE
-
-                val totalCheckIns = user?.loginIncentives
-                if (remaining > 0 && totalCheckIns != null) {
-                    reviewManager.requestReview(this@ArmoireActivity, totalCheckIns)
-                }
             }
         }
 
@@ -122,6 +118,15 @@ class ArmoireActivity : BaseActivity() {
             val args = ArmoireActivityArgs.fromBundle(it)
             equipmentKey = args.key
             configure(args.type, args.key, args.text, args.value)
+
+            if (args.type == "gear") {
+                userViewModel.user?.observeOnce(this) { user ->
+                    val totalCheckIns = user?.loginIncentives
+                    if (totalCheckIns != null) {
+                        reviewManager.requestReview(this@ArmoireActivity, totalCheckIns)
+                    }
+                }
+            }
         }
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
@@ -49,7 +49,9 @@ class ArmoireActivity : BaseActivity() {
 
     @Inject
     lateinit var userViewModel: MainUserViewModel
-    private lateinit var reviewManager: ReviewManager
+
+    @Inject
+    lateinit var reviewManager: ReviewManager
 
     override fun getLayoutResId(): Int = R.layout.activity_armoire
 
@@ -121,9 +123,8 @@ class ArmoireActivity : BaseActivity() {
 
             if (args.type == "gear") {
                 userViewModel.user.observeOnce(this) { user ->
-                    val totalCheckIns = user?.loginIncentives
-                    if (totalCheckIns != null) {
-                        reviewManager.requestReview(this@ArmoireActivity, totalCheckIns)
+                    user?.loginIncentives?.let { totalCheckins ->
+                        reviewManager.requestReview(this@ArmoireActivity, totalCheckins)
                     }
                 }
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
@@ -120,7 +120,7 @@ class ArmoireActivity : BaseActivity() {
             configure(args.type, args.key, args.text, args.value)
 
             if (args.type == "gear") {
-                userViewModel.user?.observeOnce(this) { user ->
+                userViewModel.user.observeOnce(this) { user ->
                     val totalCheckIns = user?.loginIncentives
                     if (totalCheckIns != null) {
                         reviewManager.requestReview(this@ArmoireActivity, totalCheckIns)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ClassSelectionActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ClassSelectionActivity.kt
@@ -36,7 +36,9 @@ class ClassSelectionActivity : BaseActivity() {
 
     @Inject
     lateinit var userViewModel: MainUserViewModel
-    private lateinit var reviewManager: ReviewManager
+
+    @Inject
+    lateinit var reviewManager: ReviewManager
 
     private lateinit var binding: ActivityClassSelectionBinding
     private var currentClass: String? = null
@@ -303,8 +305,9 @@ class ClassSelectionActivity : BaseActivity() {
 
     private fun checkForReviewPromptAfterClassSelection() {
         userViewModel.user.observeOnce(this) { user ->
-            val totalCheckIns = user?.loginIncentives ?: return@observeOnce
-            reviewManager.requestReview(this, totalCheckIns)
+            user?.loginIncentives?.let { totalCheckins ->
+                reviewManager.requestReview(this, totalCheckins)
+            }
         }
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
@@ -27,6 +27,7 @@ import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.data.SocialRepository
 import com.habitrpg.android.habitica.databinding.ActivityFullProfileBinding
 import com.habitrpg.android.habitica.extensions.addCancelButton
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.common.habitica.helpers.MainNavigationController
 import com.habitrpg.android.habitica.helpers.UserStatComputer
 import com.habitrpg.android.habitica.models.Achievement
@@ -88,6 +89,7 @@ class FullProfileActivity : BaseActivity() {
     private val attributeRows = ArrayList<TableRow>()
     private val dateFormatter = SimpleDateFormat.getDateInstance()
     private lateinit var binding: ActivityFullProfileBinding
+    private lateinit var reviewManager: ReviewManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -97,6 +99,7 @@ class FullProfileActivity : BaseActivity() {
         if (userID.isEmpty()) {
             userID = intent?.data?.path?.removePrefix("/profile/") ?: ""
         }
+        reviewManager = ReviewManager(this)
 
         setTitle(R.string.profile_loading_data)
 
@@ -141,10 +144,16 @@ class FullProfileActivity : BaseActivity() {
                         member?.stats = this@FullProfileActivity.member.value?.stats
                         if (member != null) {
                             updateView(member)
+                            if (isMyProfile() && member.loginIncentives > 10) {
+                                reviewManager.requestReview(this@FullProfileActivity, member.loginIncentives)
+                            }
                         }
+
                         this@FullProfileActivity.member.value = member
                     }
                     invalidateOptionsMenu()
+
+
                 }
         }
     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.kt
@@ -78,6 +78,9 @@ class FullProfileActivity : BaseActivity() {
     @Inject
     lateinit var sharedPrefs: SharedPreferences
 
+    @Inject
+    lateinit var reviewManager: ReviewManager
+
     private var userID = ""
     private var username: String? = null
     private var userDisplayName: String? = null
@@ -89,7 +92,7 @@ class FullProfileActivity : BaseActivity() {
     private val attributeRows = ArrayList<TableRow>()
     private val dateFormatter = SimpleDateFormat.getDateInstance()
     private lateinit var binding: ActivityFullProfileBinding
-    private lateinit var reviewManager: ReviewManager
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
@@ -133,7 +133,9 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
 
     @Inject
     internal lateinit var appConfigManager: AppConfigManager
-    private lateinit var reviewManager: ReviewManager
+
+    @Inject
+    lateinit var reviewManager: ReviewManager
 
     lateinit var binding: ActivityMainBinding
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -55,6 +56,7 @@ import com.habitrpg.android.habitica.helpers.AppConfigManager
 import com.habitrpg.android.habitica.helpers.EventCategory
 import com.habitrpg.android.habitica.helpers.HitType
 import com.habitrpg.android.habitica.helpers.NotificationOpenHandler
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.android.habitica.helpers.SoundManager
 import com.habitrpg.android.habitica.helpers.collectAsStateLifecycleAware
 import com.habitrpg.android.habitica.interactors.CheckClassSelectionUseCase
@@ -131,6 +133,7 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
 
     @Inject
     internal lateinit var appConfigManager: AppConfigManager
+    private lateinit var reviewManager: ReviewManager
 
     lateinit var binding: ActivityMainBinding
 
@@ -204,6 +207,7 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
         launchTrace?.start()
         super.onCreate(savedInstanceState)
         DataBindingUtils.configManager = appConfigManager
+        reviewManager = ReviewManager(this)
 
         if (!viewModel.isAuthenticated) {
             val intent = Intent(this, IntroActivity::class.java)
@@ -606,6 +610,7 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
                     this.title = newTitle
                 }
             }
+            checkForReviewPrompt(user)
         }
     }
 
@@ -788,4 +793,9 @@ open class MainActivity : BaseActivity(), SnackbarActivity {
             binding.content.toolbarTitle.setPadding(0)
         }
     }
+
+    private fun checkForReviewPrompt(user: User) {
+        reviewManager.requestReview(this, user.loginIncentives)
+    }
+
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/equipment/EquipmentDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/equipment/EquipmentDetailFragment.kt
@@ -36,7 +36,9 @@ class EquipmentDetailFragment :
     override var binding: FragmentRefreshRecyclerviewBinding? = null
     @Inject
     lateinit var userViewModel: MainUserViewModel
-    private lateinit var reviewManager: ReviewManager
+
+    @Inject
+    lateinit var reviewManager: ReviewManager
 
     override fun createBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentRefreshRecyclerviewBinding {
         return FragmentRefreshRecyclerviewBinding.inflate(inflater, container, false)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/equipment/EquipmentDetailFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/equipment/EquipmentDetailFragment.kt
@@ -11,10 +11,13 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.databinding.FragmentRefreshRecyclerviewBinding
+import com.habitrpg.android.habitica.extensions.observeOnce
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.common.habitica.helpers.MainNavigationController
 import com.habitrpg.android.habitica.ui.adapter.inventory.EquipmentRecyclerViewAdapter
 import com.habitrpg.android.habitica.ui.fragments.BaseMainFragment
 import com.habitrpg.android.habitica.ui.helpers.SafeDefaultItemAnimator
+import com.habitrpg.android.habitica.ui.viewmodels.MainUserViewModel
 import com.habitrpg.common.habitica.helpers.EmptyItem
 import com.habitrpg.common.habitica.helpers.ExceptionHandler
 import com.habitrpg.common.habitica.helpers.launchCatching
@@ -31,6 +34,9 @@ class EquipmentDetailFragment :
     lateinit var inventoryRepository: InventoryRepository
 
     override var binding: FragmentRefreshRecyclerviewBinding? = null
+    @Inject
+    lateinit var userViewModel: MainUserViewModel
+    private lateinit var reviewManager: ReviewManager
 
     override fun createBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentRefreshRecyclerviewBinding {
         return FragmentRefreshRecyclerviewBinding.inflate(inflater, container, false)
@@ -50,6 +56,14 @@ class EquipmentDetailFragment :
         adapter.onEquip = {
             lifecycleScope.launchCatching {
                 inventoryRepository.equipGear(it, isCostume ?: false)
+
+                userViewModel.user.observeOnce(viewLifecycleOwner) { user ->
+                    val parentActivity = mainActivity
+                    val totalCheckIns = user?.loginIncentives
+                    if (totalCheckIns != null && parentActivity != null) {
+                        reviewManager.requestReview(parentActivity, totalCheckIns)
+                    }
+                }
             }
         }
         return super.onCreateView(inflater, container, savedInstanceState)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
@@ -52,7 +52,9 @@ class PetDetailRecyclerFragment :
     private var animalGroup: String? = null
     private var animalColor: String? = null
     internal var layoutManager: androidx.recyclerview.widget.GridLayoutManager? = null
-    private lateinit var reviewManager: ReviewManager
+
+    @Inject
+    lateinit var reviewManager: ReviewManager
 
     override var binding: FragmentRefreshRecyclerviewBinding? = null
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/inventory/stable/PetDetailRecyclerFragment.kt
@@ -9,6 +9,8 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.databinding.FragmentRefreshRecyclerviewBinding
+import com.habitrpg.android.habitica.extensions.observeOnce
+import com.habitrpg.android.habitica.helpers.ReviewManager
 import com.habitrpg.android.habitica.interactors.FeedPetUseCase
 import com.habitrpg.android.habitica.models.inventory.Egg
 import com.habitrpg.android.habitica.models.inventory.Food
@@ -50,6 +52,7 @@ class PetDetailRecyclerFragment :
     private var animalGroup: String? = null
     private var animalColor: String? = null
     internal var layoutManager: androidx.recyclerview.widget.GridLayoutManager? = null
+    private lateinit var reviewManager: ReviewManager
 
     override var binding: FragmentRefreshRecyclerviewBinding? = null
 
@@ -124,6 +127,14 @@ class PetDetailRecyclerFragment :
             lifecycleScope.launchCatching {
                 val items = inventoryRepository.equip("pet", it)
                 adapter.currentPet = items?.currentPet
+
+                userViewModel.user.observeOnce(viewLifecycleOwner) { user ->
+                    val parentActivity = mainActivity
+                    val totalCheckIns = user?.loginIncentives
+                    if (totalCheckIns != null && parentActivity != null) {
+                        reviewManager.requestReview(parentActivity, totalCheckIns)
+                    }
+                }
             }
         }
         userViewModel.user.observe(viewLifecycleOwner) { adapter.currentPet = it?.currentPet }


### PR DESCRIPTION
In-App Review manager logic -

Initial Check:
When determing to request a in-app review, first check if an initial review request has been made.
If no review has been requested before, the app takes note of the current number of user check-ins and proceeds to request a review on the next startup during the next logical break.

Logical Breaks:
After the initial in-app review request, wait for a logical break before potentially asking the user again. This is to ensure we don't pester them :)

Limit on Total Review Requests:
Request a review only up to 5 times. After that, it will not prompt the player for reviews anymore (Unless a user has checked-in 75 times before requesting 5 in-app reviews).

Check-in Limit Since First Review:
If a user has checked in more than 75 times since the very first review was requested, the app won't request another review. This is to ensure that players are not continuously prompted.

Gap Between Review Requests:
Once a review has been requested, wait until the player has checked in at least 5 more times before considering another review request. This ensures a decent gap between consecutive review prompts.
