### PR TITLE
Add Flash and Haptic Feedback to In-App Notifications

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
@@ -19,7 +20,9 @@ import com.habitrpg.android.habitica.data.InventoryRepository
 import com.habitrpg.android.habitica.data.SocialRepository
 import com.habitrpg.android.habitica.databinding.ActivityNotificationsBinding
 import com.habitrpg.android.habitica.extensions.fadeInAnimation
+import com.habitrpg.android.habitica.extensions.flash
 import com.habitrpg.android.habitica.extensions.observeOnce
+import com.habitrpg.android.habitica.helpers.HapticFeedbackManager
 import com.habitrpg.android.habitica.models.inventory.QuestContent
 import com.habitrpg.android.habitica.ui.viewmodels.NotificationsViewModel
 import com.habitrpg.common.habitica.extensions.fromHtml
@@ -197,7 +200,11 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
         badge?.text = notificationCount.toString()
 
         val dismissAllButton = header?.findViewById(R.id.dismiss_all_button) as? Button
-        dismissAllButton?.setOnClickListener { viewModel.dismissAllNotifications(notifications) }
+        dismissAllButton?.setOnClickListener {
+            it.flash()
+            HapticFeedbackManager.tap(it)
+            viewModel.dismissAllNotifications(notifications)
+        }
 
         return header
     }
@@ -324,6 +331,8 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val container = item?.findViewById(R.id.notification_item) as? View
         container?.setOnClickListener {
+            it.flash()
+            HapticFeedbackManager.tap(it)
             val resultIntent = Intent()
             resultIntent.putExtra("notificationId", notification.id)
             setResult(Activity.RESULT_OK, resultIntent)
@@ -332,6 +341,8 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val dismissButton = item?.findViewById(R.id.dismiss_button) as? ImageView
         dismissButton?.setOnClickListener {
+            it.flash()
+            HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.dismissNotification(notification)
         }
@@ -433,6 +444,8 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
         if (openable) {
             val container = item?.findViewById(R.id.notification_item) as? View
             container?.setOnClickListener {
+                it.flash()
+                HapticFeedbackManager.tap(it)
                 if (inviterId != null) {
                     FullProfileActivity.open(inviterId)
                 } else {
@@ -446,12 +459,16 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val acceptButton = item?.findViewById(R.id.accept_button) as? Button
         acceptButton?.setOnClickListener {
+            it.flash()
+            HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.accept(notification.id)
         }
 
         val rejectButton = item?.findViewById(R.id.reject_button) as? Button
         rejectButton?.setOnClickListener {
+            it.flash()
+            HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.reject(notification.id)
         }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/NotificationsActivity.kt
@@ -201,7 +201,7 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val dismissAllButton = header?.findViewById(R.id.dismiss_all_button) as? Button
         dismissAllButton?.setOnClickListener {
-            it.flash()
+            binding.root.flash()
             HapticFeedbackManager.tap(it)
             viewModel.dismissAllNotifications(notifications)
         }
@@ -341,7 +341,7 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val dismissButton = item?.findViewById(R.id.dismiss_button) as? ImageView
         dismissButton?.setOnClickListener {
-            it.flash()
+            container?.flash()
             HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.dismissNotification(notification)
@@ -459,7 +459,7 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val acceptButton = item?.findViewById(R.id.accept_button) as? Button
         acceptButton?.setOnClickListener {
-            it.flash()
+            binding.root.flash()
             HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.accept(notification.id)
@@ -467,7 +467,7 @@ class NotificationsActivity : BaseActivity(), androidx.swiperefreshlayout.widget
 
         val rejectButton = item?.findViewById(R.id.reject_button) as? Button
         rejectButton?.setOnClickListener {
-            it.flash()
+            binding.root.flash()
             HapticFeedbackManager.tap(it)
             removeNotificationAndRefresh(notification)
             viewModel.reject(notification.id)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/social/InvitationsView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/social/InvitationsView.kt
@@ -63,12 +63,12 @@ class InvitationsView @JvmOverloads constructor(
             }
 
             binding.acceptButton.setOnClickListener {
-                it.flash()
+                binding.root.flash()
                 HapticFeedbackManager.tap(it)
                 invitation.id?.let { it1 -> acceptCall?.invoke(it1) }
             }
             binding.rejectButton.setOnClickListener {
-                it.flash()
+                binding.root.flash()
                 HapticFeedbackManager.tap(it)
                 invitation.id?.let { it1 -> rejectCall?.invoke(it1) }
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/social/InvitationsView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/social/InvitationsView.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.lifecycleScope
 import com.habitrpg.android.habitica.MainNavDirections
 import com.habitrpg.android.habitica.R
 import com.habitrpg.android.habitica.databinding.ViewInvitationBinding
+import com.habitrpg.android.habitica.extensions.flash
+import com.habitrpg.android.habitica.helpers.HapticFeedbackManager
 import com.habitrpg.common.habitica.helpers.MainNavigationController
 import com.habitrpg.android.habitica.models.invitations.GenericInvitation
 import com.habitrpg.android.habitica.models.members.Member
@@ -53,15 +55,21 @@ class InvitationsView @JvmOverloads constructor(
 
             binding.root.setOnClickListener {
                 leaderID?.let { id ->
+                    it.flash()
+                    HapticFeedbackManager.tap(it)
                     val profileDirections = MainNavDirections.openProfileActivity(id)
                     MainNavigationController.navigate(profileDirections)
                 }
             }
 
             binding.acceptButton.setOnClickListener {
+                it.flash()
+                HapticFeedbackManager.tap(it)
                 invitation.id?.let { it1 -> acceptCall?.invoke(it1) }
             }
             binding.rejectButton.setOnClickListener {
+                it.flash()
+                HapticFeedbackManager.tap(it)
                 invitation.id?.let { it1 -> rejectCall?.invoke(it1) }
             }
         }

--- a/common/src/main/java/com/habitrpg/common/habitica/extensions/ViewExt.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/extensions/ViewExt.kt
@@ -2,6 +2,8 @@ package com.habitrpg.android.habitica.extensions
 
 import android.animation.ObjectAnimator
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.view.View
 import android.view.ViewTreeObserver
 import com.habitrpg.common.habitica.extensions.dpToPx
@@ -38,3 +40,12 @@ fun View.fadeInAnimation(duration: Long = 500) {
     fadeInAnimation.duration = duration
     fadeInAnimation.start()
 }
+
+fun View.flash() {
+    val originalColor = (background as? ColorDrawable)?.color
+    setBackgroundColor(Color.LTGRAY)
+    postDelayed({
+        originalColor?.let { setBackgroundColor(it) } ?: setBackgroundResource(0)
+    }, 100)
+}
+


### PR DESCRIPTION
Add both flash and haptic feedback enhancements to the in-app notifications

- when a notification is tapped, it briefly changes its background color to simulate a "flash" effect, providing immediate visual feedback.
- tapping a notification now triggers a short vibration, giving tactile feedback to the player.