### PR TITLE
Fixes #2041 - Match checklist text margins with parent content

### DIFF
--- a/Habitica/res/layout/checklist_item_row.xml
+++ b/Habitica/res/layout/checklist_item_row.xml
@@ -32,7 +32,8 @@
         style="@style/Body2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="5dp"
-        android:paddingStart="16dp"
-        android:layout_gravity="center_vertical"/>
+        android:paddingVertical="5dp"
+        android:layout_marginHorizontal="@dimen/task_text_padding"
+        android:layout_gravity="center_vertical"
+        tools:text="Example checklist item" />
 </LinearLayout>


### PR DESCRIPTION
Matches checklist text margins with the parent content so that they align.

Screenshot:

![image](https://github.com/HabitRPG/habitica-android/assets/1057406/7ea7ce14-f5ef-4e57-94c8-bb0c5c5d06eb)


my Habitica User-ID: `caef89d8-3a3d-4d3b-a5ad-67cb0455a56e`
