### PR TITLE
Fixes #1861: Make the entire like layout clickable vs just the text

### DIFF
--- a/Habitica/res/layout/chat_item.xml
+++ b/Habitica/res/layout/chat_item.xml
@@ -72,15 +72,18 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:layout_marginStart="5dp"
+                        android:clickable="true"
+                        android:focusable="true"
                         android:background="@drawable/layout_rounded_bg">
+
                         <TextView
                             android:id="@+id/tvLikes"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_margin="5dp"
-                            android:clickable="true"
-                            android:gravity="center_vertical"
-                            android:focusable="true" />
+                            android:clickable="false"
+                            android:focusable="false"
+                            android:gravity="center_vertical" />
                     </LinearLayout>
             </LinearLayout>
             <TextView

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/ChatRecyclerViewHolder.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewHolders/ChatRecyclerViewHolder.kt
@@ -76,7 +76,7 @@ class ChatRecyclerMessageViewHolder(
         itemView.setOnClickListener {
             onShouldExpand?.invoke()
         }
-        binding.tvLikes.setOnClickListener {
+        binding.likeBackgroundLayout.setOnClickListener {
             chatMessage?.let {
                 if (it.uuid != userId) {
                     onLikeMessage?.invoke(it)


### PR DESCRIPTION
Previously just the text itself was clickable here, so I made the parent layout clickable instead. Ideally this layout would be a bit larger for a11y reasons, Google recommends 48dp minimum touch target size ([link](https://support.google.com/accessibility/android/answer/7101858?hl=en)) but I left the sizing as-is for now.

my Habitica User-ID: `caef89d8-3a3d-4d3b-a5ad-67cb0455a56e`
