### PR TITLE
fix.2058: Help text says 'Email' in the text box when trying to edit …

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/ValidatingEditText.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/ValidatingEditText.kt
@@ -29,6 +29,7 @@ class ValidatingEditText @JvmOverloads constructor(
         get() = binding.editText.hint
         set(value) {
             binding.editText.hint = value
+            binding.inputLayout.hint = value
         }
     var validator: ((String?) -> Boolean)? = null
 


### PR DESCRIPTION
…your Display Name

The solution to fix this error was to define the hint in both places (binding.editText.hint and binding.inputLayout.hint), due to the hierarchy of the layout being used. The TextInputLayout is used to create a floating label for the EditText. For the floating label to work correctly, the hint must be defined in both EditText and TextInputLayout.

Before:
![image](https://github.com/HabitRPG/habitica-android/assets/88861731/7378f910-81ad-4450-84d8-31a07604b1e7)


After:
![image](https://github.com/HabitRPG/habitica-android/assets/88861731/e02983c5-dbdd-4560-899c-a14ba1af57ee)



my Habitica User-ID: f6e70489-0c97-49d1-abe0-032779cf9550
