### PR TITLE
Check that a string contains markdown symbols instead of matches

### DIFF
--- a/common/src/main/java/com/habitrpg/common/habitica/helpers/MarkdownParser.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/helpers/MarkdownParser.kt
@@ -204,12 +204,12 @@ object MarkdownParser {
         return EmojiParser.convertToCheatCode(input.toString())
     }
 
-    private val markdownRegex = ".*[*#_\\[`~].*".toRegex()
+    private val markdownRegex = "[*#_\\[`~]".toRegex()
     private val imageMarkdownRegex = """!\[.*?]\(.*?".*?"\)""".toRegex()
     private val markdownLinkRegex = "\\[([^\\]]+)\\]\\(([^\\)]+)\\)".toRegex()
 
     fun containsMarkdown(text: String): Boolean {
-        return text.matches(markdownRegex) ||
+        return text.contains(markdownRegex) ||
             text.contains(imageMarkdownRegex) ||
             text.contains(markdownLinkRegex)
     }


### PR DESCRIPTION
.* does not match line breaks, so this regex would never apply to multiline text. This checks for contains instead of using .* to account for this.

Fixes #2049



my Habitica User-ID: 297173d0-c9f8-4eb3-818c-53f699214c98
