### PR TITLE
Adapt to orientation changes in MainActivity.

### DIFF
--- a/Habitica/AndroidManifest.xml
+++ b/Habitica/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:name=".ui.activities.MainActivity"
             android:theme="@style/LaunchAppTheme"
             android:windowSoftInputMode="stateHidden|adjustResize"
-            android:configChanges="screenSize | smallestScreenSize | screenLayout | orientation"
+            android:configChanges="screenSize | smallestScreenSize | screenLayout"
             android:exported="true">
             <nav-graph android:value="@navigation/navigation" />
             <intent-filter>


### PR DESCRIPTION
MainActivity defines an alternate layout for screen more than 600dp wide, but was ignoring orientation changes.

This caused a bug where if the application was opened with a wide orientation, but then the orientation changed to a small one, the user would be presented with the wide layout compressed into an unusable screen.

fixes #2002

my Habitica User-ID: 297173d0-c9f8-4eb3-818c-53f699214c98
