### PR TITLE
[Improvement] Apply top margins to notification prompt views in create habit/daily screen

### DIFF
--- a/Habitica/res/layout/activity_task_form.xml
+++ b/Habitica/res/layout/activity_task_form.xml
@@ -217,7 +217,7 @@
                     android:id="@+id/notifications_disabled_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/spacing_medium">
+                    android:layout_marginVertical="@dimen/spacing_medium">
 
                     <TextView
                         android:id="@+id/notifications_enabled_text"
@@ -238,7 +238,7 @@
                     android:id="@+id/exact_alarm_disabled_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/spacing_medium"
+                    android:layout_marginVertical="@dimen/spacing_medium"
                     android:background="@drawable/layout_rounded_bg_yellow_10">
 
                     <TextView


### PR DESCRIPTION
I noticed that the notification prompts on the create habits/dailies screen were touching the views above them. This PR just adds the same top margin that was being applied as bottom margins, so that the notification prompts have some space.

| Before | After |
| ----- | ----- |
| <img src="https://github.com/user-attachments/assets/007b0391-8247-4eac-ae2b-d7caa881c52a" width="300" /> | <img src="https://github.com/user-attachments/assets/beb1589d-7ed0-4b23-bed5-df0487633e9c" width="300" /> |
| <img src="https://github.com/user-attachments/assets/bb7f1ad6-5da1-46d8-b7bc-1f73342fe564" width="300" /> | <img src="https://github.com/user-attachments/assets/43c18efb-4c81-4f17-97de-a2a998b3f79c" width="300" /> |

my Habitica User-ID: caef89d8-3a3d-4d3b-a5ad-67cb0455a56e
