### PR TITLE
[Fix] Remove memory leaks in ArmoireActivity by ending infinite animations in onPause

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/ArmoireActivity.kt
@@ -399,4 +399,17 @@ class ArmoireActivity : BaseActivity() {
         dialog.setContentView(R.layout.armoire_drop_rate_dialog)
         dialog.show()
     }
+
+    override fun onPause() {
+        super.onPause()
+        // Clear infinite animations on pause to make sure Context references aren't leaked.
+        stopInfiniteAnimations()
+    }
+
+    private fun stopInfiniteAnimations() {
+        binding.leftSparkView.stopAnimating()
+        binding.rightSparkView.stopAnimating()
+        binding.iconView.animation?.cancel()
+        binding.iconView.animation = null
+    }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/SparkView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/SparkView.kt
@@ -27,6 +27,7 @@ constructor(
             invalidate()
         }
     private var paint: Paint = Paint()
+    private var animator: ValueAnimator? = null
 
     var thickness = 3.dpToPx(context)
     var length = 6.dpToPx(context)
@@ -59,15 +60,16 @@ constructor(
     }
 
     fun startAnimating() {
-        val anim = ObjectAnimator.ofFloat(thickness.toFloat(), maxSpacing.toFloat())
-        anim.addUpdateListener {
-            spacing = it.animatedValue as Float
+        animator = ObjectAnimator.ofFloat(thickness.toFloat(), maxSpacing.toFloat()).apply {
+            addUpdateListener {
+                spacing = it.animatedValue as Float
+            }
+            interpolator = AccelerateDecelerateInterpolator()
+            repeatCount = Animation.INFINITE
+            repeatMode = ValueAnimator.REVERSE
+            duration = animationDuration
+            start()
         }
-        anim.interpolator = AccelerateDecelerateInterpolator()
-        anim.repeatCount = Animation.INFINITE
-        anim.repeatMode = ValueAnimator.REVERSE
-        anim.duration = animationDuration
-        anim.start()
     }
 
     override fun onMeasure(
@@ -138,5 +140,10 @@ constructor(
             thickness / 2f,
             paint
         )
+    }
+
+    fun stopAnimating() {
+        animator?.end()
+        animator = null
     }
 }


### PR DESCRIPTION
On an orientation change, I noticed that LeakCanary was reporting Context memory leaks in `ArmoireActivity`:

<img src="https://github.com/user-attachments/assets/249106ea-7ffe-47d4-8655-0d92a4adc846" width="300" />

Upon investigation, these leaks were coming from underlying views infinite animations maintaining `ArmoireActivity`'s Context after it was destroyed. Ending/cancelling these infinite animations in `ArmoireActivity`s `onPause` removes these memory leaks, and animations still re-play on an orientation change. Here is a recording of an orientation change after these changes:

<video src="https://github.com/user-attachments/assets/db699537-32f9-4b75-951d-cd2bbab2e31b" width="600"></video>

my Habitica User-ID: caef89d8-3a3d-4d3b-a5ad-67cb0455a56e
