### PR TITLE
Fix status bar color after closing a BottomSheet

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/BottomSheetUtils.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/BottomSheetUtils.kt
@@ -94,7 +94,6 @@ private fun BottomSheetWrapper(
         systemUiController.setNavigationBarColor(navigationbarColor, darkIcons = true)
         onDispose {
             systemUiController.setNavigationBarColor(navigationbarColor, darkIcons = false)
-            systemUiController.setStatusBarColor(statusBarColor.copy(alpha = 0.3f), darkIcons = true)
         }
     }
 


### PR DESCRIPTION
When the BottomSheet goes to the hidden state, the status bar resets to the default. However, in the `DisposableEffect(systemUiController)`'s `onDispose` block, the status bar is set again to the BottomSheet's theme.

See `LaunchedEffect(modalBottomSheetState.currentValue)`.

Fixes https://github.com/HabitRPG/habitica-android/issues/2104

my Habitica User-ID: `bda342f8-31e6-4ee6-adcc-03c307d562ef`
