### PR TITLE
Limits height of party description input

### DIFF
--- a/Habitica/res/layout/activity_group_form.xml
+++ b/Habitica/res/layout/activity_group_form.xml
@@ -72,6 +72,7 @@
                     android:id="@+id/group_description_edit_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:maxHeight="250dp"
                     android:layout_gravity="center_horizontal"
                     android:inputType="textCapSentences|textMultiLine"
                     android:textColorHint="@color/text_primary"


### PR DESCRIPTION
Sets a maximum height for the group description field.

This prevents the text input from expanding indefinitely and
occupying too much screen space when users enter long descriptions.
