### PR TITLE
Fixes incorrect week calculation for monthly repeats

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
@@ -199,8 +199,11 @@ constructor(
             weeksOfMonth = null
             generateSummary()
         }
+
         binding.monthlyRepeatWeeks.setOnClickListener {
-            weeksOfMonth = mutableListOf(startDateCalendar.get(Calendar.WEEK_OF_MONTH) - 1)
+            val dayOfMonth = startDateCalendar.get(Calendar.DAY_OF_MONTH)
+            val zeroBasedWeekIdx = (dayOfMonth - 1) / 7
+            weeksOfMonth = mutableListOf(zeroBasedWeekIdx)
             daysOfMonth = null
             generateSummary()
         }


### PR DESCRIPTION
Using the built-in "week of month" value meant that any days before the 1st counted as “week 1,” so selecting the first Monday sometimes grabbed a date that actually belonged to a partial week from the previous month.

The new approach replaces that by taking the numeric day (1-31) and grouping 1-7 as week 1, 8–14 as week 2, and so on - so "first Monday" really means the first Monday falling in days 1–7 of that month, not a stray day from a partial week.
