### PR TITLE
(WearOS) Removes task observer after all tasks are completed

### DIFF
--- a/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/activities/RYAActivity.kt
+++ b/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/activities/RYAActivity.kt
@@ -37,11 +37,15 @@ class RYAActivity : BaseActivity<ActivityRyaBinding, RYAViewModel>() {
                     } else {
                         binding.scrollView.isVisible = true
                         createTaskListViews(value)
-                        viewModel.tasks.removeObserver(this)
+                        // only remove the observer if all tasks are completed
+                        if (viewModel.areAllTasksCompleted(value)) {
+                            viewModel.tasks.removeObserver(this)
+                        }
                     }
                 }
             }
         )
+
 
         binding.ryaButton.setOnClickListener {
             binding.titleView.text = getString(R.string.check_off_yesterday)

--- a/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/viewmodels/RYAViewModel.kt
+++ b/wearos/src/main/java/com/habitrpg/wearos/habitica/ui/viewmodels/RYAViewModel.kt
@@ -72,4 +72,9 @@ constructor(
             appStateManager.endLoading()
         }
     }
+
+    fun areAllTasksCompleted(tasks: List<Task>): Boolean {
+        return tasks.all { it.completed }
+    }
+
 }


### PR DESCRIPTION
The task observer is now only removed after all tasks are completed, allowing due tasks to be checked.
