### PR TITLE
Show empty state view once messages load (Or no messages)

### DIFF
--- a/Habitica/res/layout/fragment_chat.xml
+++ b/Habitica/res/layout/fragment_chat.xml
@@ -3,6 +3,20 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/chat_empty_textview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:visibility="gone"
+        android:padding="16dp"
+        android:layout_weight="1"
+        android:layout_gravity="center"
+        android:text="@string/chat_empty_state"
+        android:textColor="@color/gray200_gray400"
+        android:textSize="16sp" />
+
     <com.habitrpg.android.habitica.ui.helpers.RecyclerViewEmptySupport
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -1580,6 +1580,9 @@
     <string name="auth_get_credentials_error">Error getting credentials for authentication.</string>
     <string name="auth_invalid_credentials">Received invalid credentials.</string>
     <string name="auth_unknown_error">Unknown error during authentication.</string>
+    <string name="chat_empty_state"><b>Start chatting!</b>\nRemember to be friendly and follow the Community Guidelines.</string>
+
+
 
     <plurals name="you_x_others">
         <item quantity="zero">You</item>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
@@ -31,6 +31,7 @@ import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.Companion.showSna
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.SnackbarDisplayType
 import com.habitrpg.android.habitica.ui.views.dialogs.HabiticaAlertDialog
 import com.habitrpg.common.habitica.extensions.observeOnce
+import com.habitrpg.common.habitica.helpers.RecyclerViewState
 import com.habitrpg.common.habitica.helpers.launchCatching
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -219,10 +220,16 @@ open class ChatFragment : BaseFragment<FragmentChatBinding>() {
         chatAdapter?.data = chatMessages
         binding?.chatBarView?.chatMessages = chatMessages
 
-        viewModel.gotNewMessages = true
+        binding?.recyclerView?.state = if (chatMessages.isEmpty()) {
+            RecyclerViewState.EMPTY
+        } else {
+            RecyclerViewState.DISPLAYING_DATA
+        }
 
+        viewModel.gotNewMessages = true
         markMessagesAsSeen()
     }
+
 
     private fun sendChatMessage(chatText: String) {
         viewModel.postGroupChat(

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/ChatFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isGone
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -30,6 +31,7 @@ import com.habitrpg.android.habitica.ui.viewmodels.GroupViewModel
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.Companion.showSnackbar
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.SnackbarDisplayType
 import com.habitrpg.android.habitica.ui.views.dialogs.HabiticaAlertDialog
+import com.habitrpg.common.habitica.extensions.fadeInAnimation
 import com.habitrpg.common.habitica.extensions.observeOnce
 import com.habitrpg.common.habitica.helpers.RecyclerViewState
 import com.habitrpg.common.habitica.helpers.launchCatching
@@ -220,10 +222,12 @@ open class ChatFragment : BaseFragment<FragmentChatBinding>() {
         chatAdapter?.data = chatMessages
         binding?.chatBarView?.chatMessages = chatMessages
 
-        binding?.recyclerView?.state = if (chatMessages.isEmpty()) {
-            RecyclerViewState.EMPTY
+         if (chatMessages.isEmpty()) {
+             binding?.recyclerView?.state = RecyclerViewState.EMPTY
+             binding?.chatEmptyTextview?.fadeInAnimation()
         } else {
-            RecyclerViewState.DISPLAYING_DATA
+             binding?.recyclerView?.state = RecyclerViewState.DISPLAYING_DATA
+             binding?.chatEmptyTextview?.isGone = true
         }
 
         viewModel.gotNewMessages = true


### PR DESCRIPTION
In ChatFragment.setChatMessages(), update the RecyclerViewEmptySupport’s state to EMPTY when the message list is empty or to DISPLAYING_DATA otherwise. This replaces the loading spinner with the correct empty or data UI.
