### PR TITLE
Fix background GIF animation by checking Drawable

### DIFF
--- a/common/src/main/java/com/habitrpg/common/habitica/views/AvatarView.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/views/AvatarView.kt
@@ -205,8 +205,8 @@ class AvatarView : FrameLayout {
                             drawable.isFilterBitmap = false
                             super.onSuccess(result)
                             imageView.setImageDrawable(drawable)
-                            if (result is Animatable) {
-                                result.start()
+                            if (drawable is Animatable) {
+                                drawable.start()
                             }
                             val bounds = getLayerBounds(layerKey, layerName, drawable)
                             imageView.imageMatrix = avatarMatrix


### PR DESCRIPTION
In onSuccess, use if (drawable is Animatable) to start GIFs instead of checking the Coil Image result.
