### PR TITLE
Unregister and clear push device on logout

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/HabiticaBaseApplication.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/HabiticaBaseApplication.kt
@@ -11,8 +11,6 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.database.DatabaseErrorHandler
 import android.database.sqlite.SQLiteDatabase
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
@@ -33,6 +31,8 @@ import com.habitrpg.android.habitica.extensions.DateUtils
 import com.habitrpg.android.habitica.helpers.AdHandler
 import com.habitrpg.android.habitica.helpers.Analytics
 import com.habitrpg.android.habitica.helpers.notifications.PushNotificationManager
+import com.habitrpg.android.habitica.helpers.notifications.PushNotificationManager.Companion.DEVICE_TOKEN_PREFERENCE_KEY
+import com.habitrpg.android.habitica.models.user.User
 import com.habitrpg.android.habitica.modules.AuthenticationHandler
 import com.habitrpg.android.habitica.ui.activities.BaseActivity
 import com.habitrpg.android.habitica.ui.activities.LoginActivity
@@ -318,15 +318,26 @@ abstract class HabiticaBaseApplication : Application(), Application.ActivityLife
             realm.close()
         }
 
-        fun logout(context: Context) {
+        fun logout(context: Context, user: User? = null) {
             MainScope().launchCatching {
-                getInstance(context)?.pushNotificationManager?.removePushDeviceUsingStoredToken()
-                deleteDatabase(context)
                 val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+                val instance      = getInstance(context)
+                val pushManager   = instance?.pushNotificationManager
+                val deviceToken   = preferences.getString(DEVICE_TOKEN_PREFERENCE_KEY, "") ?: ""
+
                 val useReminder = preferences.getBoolean("use_reminder", false)
                 val reminderTime = preferences.getString("reminder_time", "19:00")
                 val lightMode = preferences.getString("theme_mode", "system")
                 val launchScreen = preferences.getString("launch_screen", "")
+
+                // set the user and refreshed token in the push manager, so we can remove the push device
+                if (deviceToken.isNotEmpty() && user != null) {
+                    pushManager?.setUser(user)
+                    pushManager?.refreshedToken = deviceToken
+                    pushManager?.removePushDeviceUsingStoredToken()
+                }
+
+                deleteDatabase(context)
                 preferences.edit {
                     clear()
                     putBoolean("use_reminder", useReminder)
@@ -334,7 +345,9 @@ abstract class HabiticaBaseApplication : Application(), Application.ActivityLife
                     putString("theme_mode", lightMode)
                     putString("launch_screen", launchScreen)
                 }
-                getInstance(context)?.lazyApiHelper?.updateAuthenticationCredentials(null, null)
+                pushManager?.clearUser()
+
+                instance?.lazyApiHelper?.updateAuthenticationCredentials(null, null)
                 Wearable.getCapabilityClient(context).removeLocalCapability("provide_auth")
                 startActivity(LoginActivity::class.java, context)
             }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
@@ -37,6 +37,14 @@ class PushNotificationManager(
         this.user = user
     }
 
+    fun clearUser() {
+        this.user = null
+        this.refreshedToken = ""
+        sharedPreferences.edit {
+            remove(DEVICE_TOKEN_PREFERENCE_KEY)
+        }
+    }
+
     /**
      * New installs on Android 13 require
      * Notification permissions be approved.
@@ -131,7 +139,7 @@ class PushNotificationManager(
         const val GROUP_ACTIVITY_NOTIFICATION_KEY = "groupActivity"
         const val CONTENT_RELEASE_NOTIFICATION_KEY = "contentRelease"
         const val G1G1_PROMO_KEY = "g1g1Promo"
-        private const val DEVICE_TOKEN_PREFERENCE_KEY = "device-token-preference"
+        const val DEVICE_TOKEN_PREFERENCE_KEY = "device-token-preference"
 
         fun displayNotification(
             remoteMessage: RemoteMessage,

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/AccountPreferenceFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/AccountPreferenceFragment.kt
@@ -486,7 +486,10 @@ class AccountPreferenceFragment :
             userRepository.deleteAccount(password)
             dialog?.dismiss()
             accountDialog.dismiss()
-            context?.let { HabiticaBaseApplication.logout(it) }
+            context?.let {
+                val user = userViewModel.user.value
+                HabiticaBaseApplication.logout(it, user)
+            }
             activity?.finish()
         }
     }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.kt
@@ -251,7 +251,7 @@ class PreferencesFragment :
             val dialog = HabiticaAlertDialog(context)
             dialog.setTitle(R.string.are_you_sure)
             dialog.addButton(R.string.logout, true) { _, _ ->
-                HabiticaBaseApplication.logout(context)
+                HabiticaBaseApplication.logout(context, user)
                 activity?.finish()
             }
             dialog.addCancelButton()


### PR DESCRIPTION
- In logout(), set PushNotificationManager.user and refreshedToken before calling removePushDeviceUsingStoredToken()
- Add clearUser() to null out in-memory user and remove saved DEVICE_TOKEN_PREFERENCE_KEY
- Invoke clearUser() after database reset to prevent stray notifications post-logout
