### PR TITLE
Implement challenge filtering by content categories

### DIFF
--- a/Habitica/res/layout/dialog_challenge_filter.xml
+++ b/Habitica/res/layout/dialog_challenge_filter.xml
@@ -37,6 +37,16 @@
             android:visibility="invisible"/>
     </LinearLayout>
 
+    <TextView
+        style="@style/Caption3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="14dp"
+        android:height="20dp"
+        android:gravity="center_vertical"
+        android:text="@string/category"
+        android:textAllCaps="true" />
+
         <com.habitrpg.android.habitica.ui.helpers.RecyclerViewEmptySupport
             android:id="@+id/challenge_filter_recycler_view"
             android:layout_width="match_parent"

--- a/Habitica/res/layout/dialog_challenge_filter_group_item.xml
+++ b/Habitica/res/layout/dialog_challenge_filter_group_item.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheckBox
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<CheckBox xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/challenge_filter_group_checkbox"
+    style="@style/Subheader2"
     android:layout_width="match_parent"
-    android:checked="true"
     android:layout_height="wrap_content"
+    android:checked="true"
+    android:paddingStart="8dp"
     android:paddingTop="8dp"
     android:paddingBottom="8dp"
-    android:paddingStart="8dp"/>
+    android:textColor="@color/text_primary" />

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -715,6 +715,7 @@
     <string name="reply">Reply</string>
     <string name="challenge_prize">Challenge Prize</string>
     <string name="challenge_categories">Challenge Categories</string>
+    <string name="category">Category</string>
     <string name="created_challenge">Created Challenge</string>
     <string name="joined">Joined</string>
     <string name="public_challenge">Public Challenge</string>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/ChallengeRepository.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/ChallengeRepository.kt
@@ -1,5 +1,6 @@
 package com.habitrpg.android.habitica.data
 
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import com.habitrpg.android.habitica.models.social.Challenge
 import com.habitrpg.android.habitica.models.social.ChallengeMembership
 import com.habitrpg.android.habitica.models.tasks.Task
@@ -65,4 +66,6 @@ interface ChallengeRepository : BaseRepository {
         challengeid: String,
         updateData: Map<String, String>
     ): Void?
+
+    fun getCategoryOptions(): Flow<List<CategoryOption>>
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/implementation/ChallengeRepositoryImpl.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/implementation/ChallengeRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.habitrpg.android.habitica.data.ApiClient
 import com.habitrpg.android.habitica.data.ChallengeRepository
 import com.habitrpg.android.habitica.data.local.ChallengeLocalRepository
 import com.habitrpg.android.habitica.models.LeaveChallengeBody
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import com.habitrpg.android.habitica.models.social.Challenge
 import com.habitrpg.android.habitica.models.social.ChallengeMembership
 import com.habitrpg.android.habitica.models.tasks.Task
@@ -190,5 +191,9 @@ class ChallengeRepositoryImpl(
         val returnedChallenge = apiClient.joinChallenge(challenge.id ?: "") ?: return null
         localRepository.setParticipating(currentUserID, returnedChallenge.id ?: "", true)
         return returnedChallenge
+    }
+
+    override fun getCategoryOptions(): Flow<List<CategoryOption>> {
+        return localRepository.getCategoryOptions()
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/ChallengeLocalRepository.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/ChallengeLocalRepository.kt
@@ -1,5 +1,6 @@
 package com.habitrpg.android.habitica.data.local
 
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import com.habitrpg.android.habitica.models.social.Challenge
 import com.habitrpg.android.habitica.models.social.ChallengeMembership
 import com.habitrpg.android.habitica.models.tasks.Task
@@ -38,4 +39,6 @@ interface ChallengeLocalRepository : BaseLocalRepository {
         userID: String,
         challengeID: String
     ): Flow<Boolean>
+
+    fun getCategoryOptions(): Flow<List<CategoryOption>>
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmChallengeLocalRepository.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmChallengeLocalRepository.kt
@@ -1,6 +1,8 @@
 package com.habitrpg.android.habitica.data.local.implementation
 
 import com.habitrpg.android.habitica.data.local.ChallengeLocalRepository
+import com.habitrpg.android.habitica.models.ContentResult
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import com.habitrpg.android.habitica.models.social.Challenge
 import com.habitrpg.android.habitica.models.social.ChallengeMembership
 import com.habitrpg.android.habitica.models.tasks.Task
@@ -146,5 +148,13 @@ class RealmChallengeLocalRepository(realm: Realm) :
             }
         }
         executeTransaction { realm1 -> realm1.insertOrUpdate(challenges) }
+    }
+
+    override fun getCategoryOptions(): Flow<List<CategoryOption>> {
+        return realm.where(CategoryOption::class.java)
+            .findAll()
+            .toFlow()
+            .filter { it.isLoaded }
+            .map { it.toList() }
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmContentLocalRepository.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/data/local/implementation/RealmContentLocalRepository.kt
@@ -24,6 +24,7 @@ open class RealmContentLocalRepository(realm: Realm) :
             realm1.insertOrUpdate(contentResult.food)
             realm1.insertOrUpdate(contentResult.hatchingPotions)
             realm1.insertOrUpdate(contentResult.special)
+            realm1.insertOrUpdate(contentResult.categoryOptions)
 
             realm1.insertOrUpdate(contentResult.pets)
             realm1.insertOrUpdate(contentResult.mounts)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/CategoryOptionExtensions.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/extensions/CategoryOptionExtensions.kt
@@ -1,0 +1,29 @@
+package com.habitrpg.android.habitica.extensions
+
+import android.content.Context
+import com.habitrpg.android.habitica.models.social.CategoryOption
+import com.habitrpg.android.habitica.models.social.Challenge
+import com.habitrpg.android.habitica.models.social.Group
+
+
+fun CategoryOption.toFilterGroup(): Group {
+    return Group().apply {
+        id = key
+        name = label
+            .split('_')
+            .joinToString(" ") { word ->
+                word.replaceFirstChar { it.uppercaseChar() }
+            }
+    }
+}
+
+fun List<CategoryOption>.toFilterGroups(): List<Group> =
+    map { it.toFilterGroup() }
+
+fun List<Challenge>.filterByCategorySlugs(activeGroupIds: Set<String>): List<Challenge> {
+    return this.filter { challenge ->
+        challenge.categories.any { category ->
+            activeGroupIds.contains(category.slug)
+        }
+    }
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/ContentResult.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/ContentResult.kt
@@ -10,6 +10,7 @@ import com.habitrpg.android.habitica.models.inventory.Mount
 import com.habitrpg.android.habitica.models.inventory.Pet
 import com.habitrpg.android.habitica.models.inventory.QuestContent
 import com.habitrpg.android.habitica.models.inventory.SpecialItem
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import io.realm.RealmList
 
 /**
@@ -31,4 +32,5 @@ class ContentResult {
     var faq = RealmList<FAQArticle>()
     var special = RealmList<SpecialItem>()
     var mystery = RealmList<EquipmentSet>()
+    var categoryOptions = RealmList<CategoryOption>()
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/CategoryOption.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/CategoryOption.kt
@@ -1,0 +1,10 @@
+package com.habitrpg.android.habitica.models.social
+
+import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
+
+open class CategoryOption : RealmObject() {
+    @PrimaryKey
+    var key: String = ""
+    var label: String = ""
+}

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/Challenge.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/Challenge.kt
@@ -3,6 +3,7 @@ package com.habitrpg.android.habitica.models.social
 import com.habitrpg.android.habitica.models.BaseMainObject
 import com.habitrpg.android.habitica.models.user.User
 import com.habitrpg.shared.habitica.models.tasks.TasksOrder
+import io.realm.RealmList
 import io.realm.RealmModel
 import io.realm.RealmObject
 import io.realm.annotations.Ignore
@@ -28,6 +29,8 @@ open class Challenge : RealmObject(), BaseMainObject {
     var rewardList: String? = null
     var createdAt: Date? = null
     var updatedAt: Date? = null
+
+    var categories: RealmList<ChallengeCategory> = RealmList()
 
     var group: Group? = null
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/ChallengeCategory.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/models/social/ChallengeCategory.kt
@@ -1,0 +1,11 @@
+package com.habitrpg.android.habitica.models.social
+
+import io.realm.RealmObject
+import io.realm.annotations.PrimaryKey
+
+open class ChallengeCategory(
+    @PrimaryKey
+    var id: String = "",
+    var slug: String = "",
+    var name: String = ""
+) : RealmObject()

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeListFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/challenges/ChallengeListFragment.kt
@@ -11,6 +11,8 @@ import com.habitrpg.android.habitica.data.ChallengeRepository
 import com.habitrpg.android.habitica.data.SocialRepository
 import com.habitrpg.android.habitica.data.UserRepository
 import com.habitrpg.android.habitica.databinding.FragmentRefreshRecyclerviewBinding
+import com.habitrpg.android.habitica.extensions.toFilterGroups
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import com.habitrpg.android.habitica.models.social.Challenge
 import com.habitrpg.android.habitica.models.social.Group
 import com.habitrpg.android.habitica.ui.adapter.social.ChallengesListViewAdapter
@@ -23,6 +25,7 @@ import com.habitrpg.common.habitica.helpers.MainNavigationController
 import com.habitrpg.common.habitica.helpers.launchCatching
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -59,6 +62,7 @@ class ChallengeListFragment :
 
     private var challenges: List<Challenge>? = null
     private var filterGroups: MutableList<Group>? = null
+    private var categoryOptions: List<CategoryOption> = emptyList()
 
     private var filterOptions: ChallengeFilterOptions? = null
 
@@ -106,6 +110,14 @@ class ChallengeListFragment :
                     this@ChallengeListFragment.filterGroups = mutableListOf()
                     it.first?.let { tavern -> filterGroups?.add(tavern) }
                     filterGroups?.addAll(it.second)
+                }
+        }
+
+        lifecycleScope.launchCatching {
+            challengeRepository.getCategoryOptions()
+                .filter { it.isNotEmpty() }
+                .collect { categoryOptions ->
+                    this@ChallengeListFragment.categoryOptions = categoryOptions
                 }
         }
 
@@ -191,10 +203,14 @@ class ChallengeListFragment :
     }
 
     internal fun showFilterDialog() {
-        activity?.let {
+        activity?.let { activity ->
+            val socialGroups = filterGroups ?: emptyList()
+            val categoryGroups = categoryOptions.toFilterGroups()
+            val allGroups: List<Group> = socialGroups + categoryGroups
+
             ChallengeFilterDialogHolder.showDialog(
-                it,
-                filterGroups ?: emptyList(),
+                activity,
+                allGroups,
                 filterOptions
             ) {
                 changeFilter(it)

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/utils/ChallengeDeserializer.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/utils/ChallengeDeserializer.kt
@@ -10,6 +10,7 @@ import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
 import com.habitrpg.android.habitica.extensions.getAsString
 import com.habitrpg.android.habitica.models.social.Challenge
+import com.habitrpg.android.habitica.models.social.ChallengeCategory
 import java.lang.reflect.Type
 import java.util.Date
 
@@ -57,6 +58,18 @@ class ChallengeDeserializer : JsonDeserializer<Challenge>, JsonSerializer<Challe
                         challenge.leaderId = id.asString
                     }
                 }
+            }
+        }
+
+        if (jsonObject.has("categories")) {
+            jsonObject.getAsJsonArray("categories").forEach { elem ->
+                val categoryObject = elem.asJsonObject
+                val category = ChallengeCategory().apply {
+                    slug = categoryObject.get("slug").asString
+                    name = categoryObject.get("name").asString
+                    id   = categoryObject.get("_id").asString
+                }
+                challenge.categories.add(category)
             }
         }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/utils/ContentDeserializer.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/utils/ContentDeserializer.kt
@@ -21,6 +21,7 @@ import com.habitrpg.android.habitica.models.inventory.Mount
 import com.habitrpg.android.habitica.models.inventory.Pet
 import com.habitrpg.android.habitica.models.inventory.QuestContent
 import com.habitrpg.android.habitica.models.inventory.SpecialItem
+import com.habitrpg.android.habitica.models.social.CategoryOption
 import io.realm.RealmList
 import java.lang.reflect.Type
 
@@ -104,6 +105,18 @@ class ContentDeserializer : JsonDeserializer<ContentResult> {
                 }
 
                 result.spells.add(skill)
+            }
+        }
+
+        if (obj.has("categoryOptions")) {
+            obj.getAsJsonArray("categoryOptions").forEach { elem ->
+                val o     = elem.asJsonObject
+                val label = o.get("label").asString
+                val key   = o.get("key").asString
+                result.categoryOptions.add(CategoryOption().also {
+                    it.label = label
+                    it.key = key
+                })
             }
         }
 


### PR DESCRIPTION
- Persisted the backend's CategoryOption objects in Realm by annotating key with @PrimaryKey and calling realm.insertOrUpdate(contentResult.categoryOptions) in the content save routine.

- Extended the Challenge model to include a new ChallengeCategory RealmObject (fields id, slug, name) and a RealmList<ChallengeCategory> named categories, and updated the ChallengeDeserializer to parse the JSON categories array into that list.

- Bridged each CategoryOption into an unmanaged Group for the filter dialog via CategoryOption.toFilterGroup() (setting group.id = key and human-casing the server‐provided label), plus fun List<CategoryOption>.toFilterGroups() to map the full list.

- Added fun setCategoryOptions(keys: List<String>) to ChallengesListViewAdapter to supply the adapter with the full set of valid category slugs before filtering.

- In ChallengeListFragment, collected the getCategoryOptions() Flow into categoryOptions, invoked adapter.setCategoryOptions(categoryOptions.map { it.key }), and merged the resulting "category" Groups with social groups (Tavern/Guild) before calling ChallengeFilterDialogHolder.showDialog().

- Rewrote the adapter's filter() method to split the checked Group.id values into real group UUIDs (filtering on groupId) versus content‐category slugs (filtering on categories.slug), applied both in the same Realm query, and kept the existing owned / not-owned logic so that selecting any checkbox immediately narrows the displayed challenges exactly like on web.

- Added the “Category” header above the RecyclerView in dialog_challenge_filter.xml, using the @style/Caption3 TextView and a new @string/category resource.

- Added ChallengeCategory RealmObject class with id, slug, and name fields

- Added var categories: RealmList<ChallengeCategory> to the Challenge model

- Created fun CategoryOption.toFilterGroup() and fun List<CategoryOption>.toFilterGroups() extension functions to bridge to Group instances

- Added fun getCategoryOptions(): Flow<List<CategoryOption>> to the ChallengeLocalRepository interface and implemented it in RealmChallengeLocalRepository to stream the persisted categoryOptions.
