### PR TITLE
Fix changing display modes in settings creates multiple instances of settings

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/PrefsActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/PrefsActivity.kt
@@ -23,10 +23,12 @@ class PrefsActivity :
         super.onCreate(savedInstanceState)
 
         setupToolbar(findViewById(R.id.toolbar))
-
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, PreferencesFragment())
-            .commit()
+        
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, PreferencesFragment())
+                .commit()
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {


### PR DESCRIPTION
- Wrap initial fragment transaction in if (savedInstanceState == null) so if the activity recreates (theme or system UI changes), fragments don’t stack
