### PR TITLE
Improve empty state handling in inbox message list

### DIFF
--- a/Habitica/res/layout/tavern_chat_intro_item.xml
+++ b/Habitica/res/layout/tavern_chat_intro_item.xml
@@ -72,6 +72,8 @@
         android:layout_height="42dp"
         android:layout_gravity="center"
         android:layout_marginTop="8dp"
+        android:layout_marginStart="@dimen/spacing_medium"
+        android:layout_marginEnd="@dimen/spacing_medium"
         android:layout_marginBottom="8dp"
         android:lineSpacingMultiplier="1.0"
         android:text="Start chatting below! Remember to be friendly and follow the Community Guidelines."

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/InboxMessageListFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/InboxMessageListFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.RecyclerView
 import com.habitrpg.android.habitica.R
@@ -35,6 +36,7 @@ import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar
 import com.habitrpg.android.habitica.ui.views.HabiticaSnackbar.Companion.showSnackbar
 import com.habitrpg.android.habitica.ui.views.dialogs.HabiticaAlertDialog
 import com.habitrpg.common.habitica.helpers.ExceptionHandler
+import com.habitrpg.common.habitica.helpers.RecyclerViewState
 import com.habitrpg.common.habitica.helpers.launchCatching
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -119,6 +121,18 @@ class InboxMessageListFragment : BaseMainFragment<FragmentInboxMessageListBindin
             markMessagesAsRead(it)
             lifecycleScope.launchCatching {
                 chatAdapter?.submitData(it)
+            }
+        }
+
+        chatAdapter?.addLoadStateListener { loadStates ->
+            val isEmpty = loadStates.refresh is LoadState.NotLoading &&
+                    loadStates.append.endOfPaginationReached &&
+                    chatAdapter?.itemCount == 0
+
+            if (isEmpty) {
+                binding?.recyclerView?.state = RecyclerViewState.EMPTY
+            } else {
+                binding?.recyclerView?.state = RecyclerViewState.DISPLAYING_DATA
             }
         }
 


### PR DESCRIPTION
Add logic to display an empty state in the inbox message
list when there are no messages to display. Also adds
margins to the chat intro item.
