### PR TITLE
Enable changing server address at runtime (Self-hosted support)

### DIFF
--- a/Habitica/res/xml/network_security_config.xml
+++ b/Habitica/res/xml/network_security_config.xml
@@ -7,5 +7,6 @@
     </debug-overrides>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.0.107</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>

--- a/Habitica/res/xml/preferences_fragment.xml
+++ b/Habitica/res/xml/preferences_fragment.xml
@@ -408,4 +408,9 @@
             android:entryValues="@array/server_urls"
             android:layout="@layout/preference_child_summary" />
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="custom_server"
+        android:layout="@layout/preference_category"
+        app:isPreferenceVisible="false"/>
 </PreferenceScreen>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/preferences/PreferencesFragment.kt
@@ -71,7 +71,8 @@ class PreferencesFragment :
     private var pushNotificationsPreference: PreferenceScreen? = null
     private var emailNotificationsPreference: PreferenceScreen? = null
     private var classSelectionPreference: Preference? = null
-    private var serverUrlPreference: ListPreference? = null
+    private var customServerUrlDebugPreference: ListPreference? = null
+    private var customServerUrlReleaseCategory: PreferenceCategory? = null
     private var taskListPreference: ListPreference? = null
 
     private val classSelectionResult =
@@ -104,11 +105,13 @@ class PreferencesFragment :
         val weekdayPreference = findPreference("FirstDayOfTheWeek") as? ListPreference
         weekdayPreference?.summary = weekdayPreference.entry
 
-        serverUrlPreference = findPreference("server_url") as? ListPreference
-        serverUrlPreference?.isVisible = false
-        serverUrlPreference?.summary =
-            preferenceManager.sharedPreferences?.getString("server_url", "")
-
+        val serverUrl = preferenceManager.sharedPreferences?.getString("server_url", "")
+        customServerUrlDebugPreference = findPreference("server_url") as? ListPreference
+        customServerUrlDebugPreference?.isVisible = false
+        customServerUrlDebugPreference?.summary = serverUrl
+        customServerUrlReleaseCategory = findPreference("custom_server")
+        customServerUrlReleaseCategory?.title = serverUrl
+        
         val themePreference = findPreference("theme_name") as? ListPreference
         themePreference?.summary = themePreference.entry ?: "Default"
         val themeModePreference = findPreference("theme_mode") as? ListPreference
@@ -594,8 +597,11 @@ class PreferencesFragment :
         }
 
         if (configManager.testingLevel() == AppTestingLevel.STAFF || BuildConfig.DEBUG) {
-            serverUrlPreference?.isVisible = true
+            customServerUrlDebugPreference?.isVisible = true
             taskListPreference?.isVisible = true
+        }
+        if (BuildConfig.DEBUG.not()) {
+            customServerUrlReleaseCategory?.isVisible = customServerUrlReleaseCategory?.title.isNullOrEmpty().not()
         }
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/AuthenticationViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/AuthenticationViewModel.kt
@@ -1,6 +1,5 @@
 package com.habitrpg.android.habitica.ui.viewmodels
 
-
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
@@ -33,15 +32,13 @@ import com.habitrpg.android.habitica.helpers.HitType
 import com.habitrpg.android.habitica.models.user.User
 import com.habitrpg.android.habitica.modules.AuthenticationHandler
 import com.habitrpg.common.habitica.api.HostConfig
-import com.habitrpg.common.habitica.helpers.ExceptionHandler
+import com.habitrpg.common.habitica.api.ServerSettings
 import com.habitrpg.common.habitica.helpers.KeyHelper
-import com.habitrpg.common.habitica.helpers.launchCatching
 import com.habitrpg.common.habitica.models.auth.UserAuthResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -69,6 +66,7 @@ class AuthenticationViewModel @Inject constructor(
     private val _authenticationSuccess = MutableStateFlow<Boolean?>(null)
     private val _isUsernameValid = MutableStateFlow<Boolean?>(null)
     private var _usernameIssues = MutableStateFlow<String?>(null)
+    private val _showServerSettingsDialog: MutableStateFlow<ServerSettings?> = MutableStateFlow(null)
 
     val showAuthProgress: Flow<Boolean> = _showAuthProgress
     val authenticationError: Flow<AuthenticationErrors> = _authenticationError
@@ -78,6 +76,7 @@ class AuthenticationViewModel @Inject constructor(
         .onEach { _showAuthProgress.value = false }
     val isUsernameValid: Flow<Boolean?> = _isUsernameValid
     val usernameIssues: Flow<String?> = _usernameIssues
+    val showServerSettingsDialog: Flow<ServerSettings?> = _showServerSettingsDialog
 
     fun clearAuthenticationState() {
         _showAuthProgress.value = false
@@ -340,5 +339,28 @@ class AuthenticationViewModel @Inject constructor(
             username.value = ""
             _isUsernameValid.value = null
         }
+    }
+
+    fun onServerSettingsUnlocked() {
+        _showServerSettingsDialog.value = ServerSettings(
+            baseUrl = BuildConfig.BASE_URL,
+            customUrl = sharedPrefs.getString("server_url", null)
+        )
+    }
+
+    fun onServerSettingsChanged(newUrl: String) {
+        sharedPrefs.edit { putString("server_url", newUrl) }
+        apiClient.updateServerUrl(newAddress = newUrl)
+        onServerSettingsDismissed()
+    }
+
+    fun onServerSettingsReset(baseUrl: String) {
+        sharedPrefs.edit { remove("server_url") }
+        apiClient.updateServerUrl(newAddress = baseUrl)
+        onServerSettingsDismissed()
+    }
+
+    fun onServerSettingsDismissed() {
+        _showServerSettingsDialog.value = null
     }
 }

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/login/ServerSettingsDialog.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/login/ServerSettingsDialog.kt
@@ -1,0 +1,184 @@
+package com.habitrpg.android.habitica.ui.views.login
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.habitrpg.android.habitica.ui.theme.colors
+import com.habitrpg.common.habitica.api.ServerSettings
+import com.habitrpg.common.habitica.theme.HabiticaTheme
+
+@Composable
+fun ServerSettingsDialog(
+    serverSettings: ServerSettings,
+    onApply: (String) -> Unit,
+    onReset: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnClickOutside = false,
+        ),
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = HabiticaTheme.colors.windowBackground,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 24.dp, bottom = 16.dp),
+            ) {
+                Text(
+                    text = "Server",
+                    fontSize = 24.sp,
+                    lineHeight = 32.sp,
+                )
+                val (baseUrl, customUrl) = serverSettings
+                val radioOptions = listOf("$baseUrl (Base URL)", "Custom")
+                val (selectedOption, onOptionSelected) = remember {
+                    mutableStateOf(
+                        if (customUrl.isNullOrEmpty()) radioOptions.first() else radioOptions.last()
+                    )
+                }
+                Column(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .selectableGroup()
+                ) {
+                    radioOptions.forEach { option ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(56.dp)
+                                .selectable(
+                                    selected = (option == selectedOption),
+                                    onClick = { onOptionSelected(option) },
+                                    role = Role.RadioButton
+                                ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = (option == selectedOption),
+                                onClick = null,
+                            )
+                            Text(
+                                text = option,
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(start = 16.dp)
+                            )
+                        }
+                    }
+                }
+                var input by remember { mutableStateOf(customUrl ?: "") }
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    label = { Text("Enter custom server address") },
+                    supportingText = { Text("e.g. http://localhost:3000") },
+                    enabled = selectedOption == radioOptions.last(),
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = onDismissRequest,
+                    ) {
+                        Text("Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    val applyEnabled = if (customUrl == null) {
+                        selectedOption == radioOptions.last() && input.isNotBlank()
+                    } else {
+                        selectedOption == radioOptions.first() || input != customUrl
+                    }
+                    TextButton(
+                        onClick = {
+                            if (selectedOption == radioOptions.last()) {
+                                onApply(input)
+                            } else {
+                                onReset()
+                            }
+                        },
+                        enabled = applyEnabled,
+                    ) {
+                        Text("Apply")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Preview(
+    name = "Night", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun ServerSettingsDialogPreview() {
+    HabiticaTheme {
+        ServerSettingsDialog(
+            serverSettings = ServerSettings(
+                baseUrl = "https://habitica.com/",
+                customUrl = null
+            ),
+            onApply = {},
+            onReset = {},
+            onDismissRequest = {},
+        )
+    }
+}
+
+@Preview
+@Preview(
+    name = "Night", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+private fun ServerSettingsDialogPreviewCustomUrl() {
+    HabiticaTheme {
+        ServerSettingsDialog(
+            serverSettings = ServerSettings(
+                baseUrl = "https://habitica.com/",
+                customUrl = "localhost:3000",
+            ),
+            onApply = {},
+            onReset = {},
+            onDismissRequest = {},
+        )
+    }
+}

--- a/common/src/main/java/com/habitrpg/common/habitica/api/HostConfig.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/api/HostConfig.kt
@@ -22,16 +22,17 @@ class HostConfig {
 
     constructor(sharedPreferences: SharedPreferences, keyHelper: KeyHelper?, context: Context) {
         this.port = BuildConfig.PORT
+        val address = sharedPreferences.getString("server_url", null)
+        val addressValid = address.isNullOrBlank().not()
         if (BuildConfig.DEBUG) {
-            this.address = BuildConfig.BASE_URL
+            this.address = if (addressValid) address else BuildConfig.BASE_URL
             if (BuildConfig.TEST_USER_ID.isNotBlank()) {
                 userID = BuildConfig.TEST_USER_ID
                 apiKey = BuildConfig.TEST_USER_KEY
                 return
             }
         } else {
-            val address = sharedPreferences.getString("server_url", null)
-            if (!address.isNullOrEmpty()) {
+            if (addressValid) {
                 this.address = address
             } else {
                 this.address = context.getString(com.habitrpg.common.habitica.R.string.base_url)

--- a/common/src/main/java/com/habitrpg/common/habitica/api/ServerSettings.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/api/ServerSettings.kt
@@ -1,0 +1,6 @@
+package com.habitrpg.common.habitica.api
+
+data class ServerSettings(
+    val baseUrl: String,
+    val customUrl: String?,
+)

--- a/common/src/main/java/com/habitrpg/common/habitica/views/SequentialClickBox.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/views/SequentialClickBox.kt
@@ -1,0 +1,37 @@
+package com.habitrpg.common.habitica.helpers
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SequentialClickBox(
+    onTrigger: () -> Unit,
+    modifier: Modifier = Modifier,
+    onRemainingClicks: (Int) -> Unit = {},
+    clicksToTrigger: Int = 5,
+    timeout: Long = 1_500L,
+    content: @Composable (Modifier) -> Unit
+) {
+    var clicks by remember { mutableIntStateOf(0) }
+    var lastClickTime by remember { mutableLongStateOf(0L) }
+    val clickableModifier = modifier.clickable {
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastClickTime > timeout.coerceAtLeast(0L)) {
+            clicks = 0
+        }
+        clicks++
+        lastClickTime = currentTime
+        onRemainingClicks(clicksToTrigger - clicks)
+        if (clicks >= clicksToTrigger) {
+            clicks = 0
+            onTrigger()
+        }
+    }
+    content(clickableModifier)
+}

--- a/common/src/main/res/values/strings.constants.xml
+++ b/common/src/main/res/values/strings.constants.xml
@@ -3,7 +3,7 @@
     <!--  Prefs -->
     <string name="SP_userID" translatable="false">UserID</string>
     <string name="SP_APIToken" translatable="false">APIToken</string>
-    <string name="base_url" translatable="false">https://shrimp.habitica.com</string>
+    <string name="base_url" translatable="false">https://habitica.com</string>
 
     <!-- Local notification actions -->
     <string name="accept_party_invite" translatable="false">ACCEPT_PARTY_INVITE</string>


### PR DESCRIPTION
Fixes: https://github.com/HabitRPG/habitica-android/issues/2062

Old related issues:
https://github.com/HabitRPG/habitica-android/issues/383
https://github.com/HabitRPG/habitica-android/issues/384
https://github.com/HabitRPG/habitica-android/issues/730
https://github.com/HabitRPG/habitica-android/issues/2082

The message on Reddit:
https://www.reddit.com/r/habitica/comments/1i8xs7u/comment/m964tri/

This PR is based on [this comment](https://github.com/HabitRPG/habitica-ios/issues/873#issuecomment-617793445) in the Habitica iOS repository.

### Implementation Details

Setting a **custom URL** is implemented as a **hidden feature** and isn't visible to the average user. To access it, you need to **press the Habitica logo 5 times consecutively**, after which the **Server Settings dialog** will appear. This behavior is similar to enabling _Developer options_ on Android (where you tap the _Build number_ seven times).

- The **custom URL** is stored in Android **SharedPreferences** under the `"server_url"` tag.
- The same tag is used in the **debug build type**, where developers/testers can switch between test servers.
_Settings_ (via the DrawerLayout) → _Maintenance_ → _Server_.
- In the **release build**, the server option is **hidden by default** in preferences. Instead, it displays the **custom URL** (if set).

<details><summary>Settings and Server dialog screenshots</summary>
<p>

<img width="1080" height="2400" alt="Settings Debug" src="https://github.com/user-attachments/assets/96c57429-c760-488d-98a4-37577264f0c9" />
<img width="1080" height="2400" alt="Server dialog" src="https://github.com/user-attachments/assets/2507ddd4-dedf-4daa-b8d8-920ccbf9cde4" />


</p>
</details> 

### Results

<details><summary>Video Debug</summary>
<p>


https://github.com/user-attachments/assets/f105b518-1509-46c2-a31d-18ba07f1f30e



</p>
</details> 

<details><summary>Video Release</summary>
<p>


https://github.com/user-attachments/assets/3972e2d3-3ea3-43f1-8daf-bbe51209ddf6



</p>
</details> 

### Testing
For testing, I used a [self-hosted Habitica fork](https://github.com/awinterstein/habitica) and their [docker-compose file](https://github.com/awinterstein/habitica/blob/self-host/docker-compose.yml).

The server runs on **port 3000**, so I forwarded the port from my Nothing Phone to macOS using:

```bash
adb reverse tcp:3000 tcp:3000
```

my Habitica User-ID: `bda342f8-31e6-4ee6-adcc-03c307d562ef`
