### PR TITLE
Add self-host options to login

### DIFF
--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -1641,4 +1641,19 @@
         <item quantity="one">%d Item pending</item>
         <item quantity="other">%d Items pending</item>
     </plurals>
+    <string name="custom_server_content_description">Server options</string>
+    <string name="custom_server_title">Server configuration</string>
+    <string name="custom_server_label">Server URL</string>
+    <string name="custom_server_placeholder">https://habitica.com</string>
+    <string name="custom_server_apply">Apply</string>
+    <string name="custom_server_reset">Reset to default</string>
+    <string name="custom_server_invalid">Couldn’t understand that server address. Include http:// or https:// and a host name.</string>
+    <string name="dev_options_warning">Warning: Only use these developer settings if you know what you’re doing.</string>
+    <plurals name="dev_options_taps_remaining">
+        <item quantity="one">Developer options unlock in %d tap.</item>
+        <item quantity="other">Developer options unlock in %d taps.</item>
+    </plurals>
+    <string name="dev_options_unlocked">Developer options unlocked.</string>
+    <string name="custom_up_server_label">UnifiedPush server URL</string>
+    <string name="custom_up_server_placeholder">https://example.com</string>
 </resources>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/Analytics.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/Analytics.kt
@@ -76,14 +76,19 @@ object Analytics {
     }
 
     fun initialize(context: Context) {
-        amplitude =
-            Amplitude(
-                Configuration(
-                    context.getString(R.string.amplitude_app_id),
-                    context,
-                    optOut = true,
+        val amplitudeAppId = context.getString(R.string.amplitude_app_id)
+        if (amplitudeAppId.isNullOrBlank()) {
+            // No amplitude configuration provided; skip amplitude setup for this build.
+        } else {
+            amplitude =
+                Amplitude(
+                    Configuration(
+                        amplitudeAppId,
+                        context,
+                        optOut = true,
+                    )
                 )
-            )
+        }
         firebase = FirebaseAnalytics.getInstance(context)
     }
 

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/notifications/PushNotificationManager.kt
@@ -76,6 +76,7 @@ class PushNotificationManager(
                 // catchy catch
             }
         }
+        addUnifiedPushDeviceIfConfigured()
     }
 
     private fun addRefreshToken() {
@@ -85,6 +86,22 @@ class PushNotificationManager(
         val pushDeviceData = HashMap<String, String>()
         pushDeviceData["regId"] = this.refreshedToken
         pushDeviceData["type"] = "android"
+        MainScope().launchCatching {
+            apiClient.addPushDevice(pushDeviceData)
+        }
+    }
+
+    private fun addUnifiedPushDeviceIfConfigured() {
+        val unifiedPushUrl = sharedPreferences.getString(UNIFIED_PUSH_SERVER_KEY, null)?.trim()
+        if (unifiedPushUrl.isNullOrEmpty()) {
+            return
+        }
+        if (this.user == null) {
+            return
+        }
+        val pushDeviceData = HashMap<String, String>()
+        pushDeviceData["regId"] = unifiedPushUrl
+        pushDeviceData["type"] = "unifiedpush"
         MainScope().launchCatching {
             apiClient.addPushDevice(pushDeviceData)
         }
@@ -140,6 +157,7 @@ class PushNotificationManager(
         const val CONTENT_RELEASE_NOTIFICATION_KEY = "contentRelease"
         const val G1G1_PROMO_KEY = "g1g1Promo"
         const val DEVICE_TOKEN_PREFERENCE_KEY = "device-token-preference"
+        private const val UNIFIED_PUSH_SERVER_KEY = "unified_push_server_url"
 
         fun displayNotification(
             remoteMessage: RemoteMessage,

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/OnboardingActivity.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/OnboardingActivity.kt
@@ -71,7 +71,7 @@ class OnboardingActivity: BaseActivity() {
 
     val authenticationViewModel: AuthenticationViewModel by viewModels()
 
-    val currentStep = mutableStateOf(OnboardingSteps.SETUP)
+    val currentStep = mutableStateOf(OnboardingSteps.LOGIN)
 
     @Inject
     lateinit var configManager: AppConfigManager
@@ -90,6 +90,11 @@ class OnboardingActivity: BaseActivity() {
         supportActionBar?.hide()
         // Set default values to avoid null-responses when requesting unedited settings
         PreferenceManager.setDefaultValues(this, R.xml.preferences_fragment, false)
+
+        if (authenticationViewModel.hostConfig.hasAuthentication()) {
+            startMainActivity()
+            return
+        }
 
         binding.composeView.setContent {
             val step by currentStep

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/AuthenticationViewModel.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/viewmodels/AuthenticationViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 @HiltViewModel
 class AuthenticationViewModel @Inject constructor(
@@ -77,6 +78,66 @@ class AuthenticationViewModel @Inject constructor(
     val isUsernameValid: Flow<Boolean?> = _isUsernameValid
     private var _usernameIssues = MutableStateFlow<String?>(null)
     val usernameIssues: Flow<String?> = _usernameIssues
+
+    fun currentServerSelection(): String {
+        return sharedPrefs.getString(SERVER_OVERRIDE_KEY, hostConfig.address) ?: hostConfig.address
+    }
+
+    fun currentUnifiedPushServer(): String {
+        return sharedPrefs.getString(UNIFIED_PUSH_SERVER_KEY, "") ?: ""
+    }
+
+    fun isDevOptionsUnlocked(): Boolean {
+        return sharedPrefs.getBoolean(DEV_OPTIONS_UNLOCKED_KEY, false)
+    }
+
+    fun setDevOptionsUnlocked(unlocked: Boolean) {
+        sharedPrefs.edit {
+            putBoolean(DEV_OPTIONS_UNLOCKED_KEY, unlocked)
+        }
+    }
+
+    fun applyServerOverride(serverUrl: String?): Boolean {
+        val normalized = normalizeServerUrl(serverUrl)
+            ?: return false
+
+        sharedPrefs.edit {
+            putString(SERVER_OVERRIDE_KEY, normalized)
+        }
+
+        apiClient.updateServerUrl(normalized)
+        return true
+    }
+
+    fun updateUnifiedPushServer(serverUrl: String?) {
+        val sanitized = serverUrl?.trim()?.takeIf { it.isNotEmpty() }
+        sharedPrefs.edit {
+            if (sanitized != null) {
+                putString(UNIFIED_PUSH_SERVER_KEY, sanitized)
+            } else {
+                remove(UNIFIED_PUSH_SERVER_KEY)
+            }
+        }
+    }
+
+    fun resetServerOverride() {
+        sharedPrefs.edit {
+            remove(SERVER_OVERRIDE_KEY)
+            remove(UNIFIED_PUSH_SERVER_KEY)
+            if (!isDevOptionsUnlocked()) {
+                remove(DEV_OPTIONS_UNLOCKED_KEY)
+            }
+        }
+        apiClient.updateServerUrl(BuildConfig.BASE_URL)
+    }
+
+    private fun normalizeServerUrl(input: String?): String? {
+        val trimmed = input?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val candidate = if (trimmed.contains("://")) trimmed else "https://$trimmed"
+        val httpUrl = runCatching { candidate.toHttpUrlOrNull() }.getOrNull() ?: return null
+        val rebuilt = httpUrl.newBuilder().encodedPath("/").build().toString()
+        return rebuilt.trimEnd('/')
+    }
 
     fun validateInputs(
         username: String,
@@ -272,5 +333,11 @@ class AuthenticationViewModel @Inject constructor(
                 Log.e("AuthenticationViewModel", "Unexpected type of credential")
             }
         }
+    }
+
+    companion object {
+        private const val SERVER_OVERRIDE_KEY = "server_url"
+        private const val UNIFIED_PUSH_SERVER_KEY = "unified_push_server_url"
+        private const val DEV_OPTIONS_UNLOCKED_KEY = "dev_options_unlocked"
     }
 }

--- a/common/src/main/java/com/habitrpg/common/habitica/api/HostConfig.kt
+++ b/common/src/main/java/com/habitrpg/common/habitica/api/HostConfig.kt
@@ -22,20 +22,19 @@ class HostConfig {
 
     constructor(sharedPreferences: SharedPreferences, keyHelper: KeyHelper?, context: Context) {
         this.port = BuildConfig.PORT
-        if (BuildConfig.DEBUG) {
-            this.address = BuildConfig.BASE_URL
-            if (BuildConfig.TEST_USER_ID.isNotBlank()) {
-                userID = BuildConfig.TEST_USER_ID
-                apiKey = BuildConfig.TEST_USER_KEY
-                return
-            }
-        } else {
-            val address = sharedPreferences.getString("server_url", null)
-            if (!address.isNullOrEmpty()) {
-                this.address = address
-            } else {
-                this.address = context.getString(com.habitrpg.common.habitica.R.string.base_url)
-            }
+        val storedAddress = sharedPreferences.getString("server_url", null)?.takeIf { it.isNotBlank() }
+
+        if (BuildConfig.DEBUG && BuildConfig.TEST_USER_ID.isNotBlank()) {
+            this.address = storedAddress ?: BuildConfig.BASE_URL
+            userID = BuildConfig.TEST_USER_ID
+            apiKey = BuildConfig.TEST_USER_KEY
+            return
+        }
+
+        this.address = when {
+            storedAddress != null -> storedAddress
+            BuildConfig.DEBUG -> BuildConfig.BASE_URL
+            else -> context.getString(com.habitrpg.common.habitica.R.string.base_url)
         }
         this.userID = sharedPreferences.getString(context.getString(com.habitrpg.common.habitica.R.string.SP_userID), null) ?: ""
         this.apiKey = loadAPIKey(sharedPreferences, keyHelper)


### PR DESCRIPTION
## Summary
- add optional developer dialog on login for custom server URL
- allow cached host override to persist across restarts
- skip onboarding for authenticated users and skip Amplitude when no key

## Testing
- built and installed debug build
- built and installed prod release