### PR TITLE
Fixes HabitRPG/habitica-android#2180

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/helpers/TaskAlarmManager.kt
@@ -25,8 +25,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.time.DateTimeException
+import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
@@ -156,12 +157,14 @@ class TaskAlarmManager(
     ) {
         if (remindersItem == null) return
 
-        val now = ZonedDateTime.now().withZoneSameLocal(ZoneId.systemDefault())?.toInstant()
-        val reminderZonedTime = remindersItem.getLocalZonedDateTimeInstant()
+        val localDateTime =
+            remindersItem.time?.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_LOCAL_DATE_TIME) }
+                ?: return
 
-        if (reminderZonedTime == null || reminderZonedTime.isBefore(now)) {
-            return
-        }
+        val reminderZonedTime = localDateTime.atZone(ZoneId.systemDefault()).toInstant()
+
+        if (reminderZonedTime.isBefore(Instant.now())) return
+
 
         val intent = Intent(context, TaskReceiver::class.java)
         intent.action = remindersItem.id

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ReminderItemFormView.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/ReminderItemFormView.kt
@@ -23,6 +23,7 @@ import com.habitrpg.common.habitica.extensions.layoutInflater
 import com.habitrpg.common.habitica.helpers.LanguageHelper
 import com.habitrpg.shared.habitica.models.tasks.TaskType
 import java.text.DateFormat
+import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Date
@@ -60,6 +61,11 @@ constructor(
                 )
             }
         }
+
+    private fun currentLocalDateTime(): LocalDateTime =
+        item.time
+            ?.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_LOCAL_DATE_TIME) }
+            ?: LocalDateTime.now()
 
     var taskType = TaskType.DAILY
     var item: RemindersItem = RemindersItem()
@@ -130,30 +136,31 @@ constructor(
         binding.button.drawable.mutate().setTint(tintColor)
 
         binding.textView.setOnClickListener {
+            val ldt = currentLocalDateTime()
+
             if (taskType == TaskType.DAILY) {
-                val timePickerDialog =
-                    TimePickerDialog(
-                        context,
-                        this,
-                        item.getZonedDateTime()?.hour ?: ZonedDateTime.now().hour,
-                        item.getZonedDateTime()?.minute ?: ZonedDateTime.now().minute,
-                        android.text.format.DateFormat.is24HourFormat(context)
-                    )
-                timePickerDialog.show()
+                TimePickerDialog(
+                    context,
+                    this,
+                    ldt.hour,
+                    ldt.minute,
+                    android.text.format.DateFormat.is24HourFormat(context)
+                ).show()
             } else {
-                val zonedDateTime = (item.getZonedDateTime() ?: ZonedDateTime.now())
-                val timePickerDialog =
+                val datePickerDialog =
                     DatePickerDialog(
                         context,
                         this,
-                        zonedDateTime.year,
-                        zonedDateTime.monthValue - 1,
-                        zonedDateTime.dayOfMonth
+                        ldt.year,
+                        ldt.monthValue - 1,
+                        ldt.dayOfMonth
                     )
+
                 if ((firstDayOfWeek ?: -1) >= 0) {
-                    timePickerDialog.datePicker.firstDayOfWeek = firstDayOfWeek ?: 0
+                    datePickerDialog.datePicker.firstDayOfWeek = firstDayOfWeek ?: 0
                 }
-                timePickerDialog.show()
+
+                datePickerDialog.show()
             }
         }
         binding.textView.labelFor = binding.button.id


### PR DESCRIPTION
# Fix

Reminders are now stored and handled as time zone independent, ensuring they always fire at the intended local time regardless of travel or system time zone changes.
