### PR TITLE
Fix notification task completion not updating local app state

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/receivers/LocalNotificationActionReceiver.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/receivers/LocalNotificationActionReceiver.kt
@@ -155,17 +155,22 @@ class LocalNotificationActionReceiver : BroadcastReceiver() {
 
             context?.getString(R.string.complete_task_action) -> {
                 taskID?.let {
+                    val pendingResult = goAsync()
                     MainScope().launch(ExceptionHandler.coroutine()) {
-                        taskRepository.taskChecked(null, it, up = true, force = false) {
-                            val pair =
-                                NotifyUserUseCase.getNotificationAndAddStatsToUserAsText(
-                                    it.experienceDelta,
-                                    it.healthDelta,
-                                    it.goldDelta,
-                                    it.manaDelta,
-                                    it.questDamage
-                                )
-                            showToast(pair.first)
+                        try {
+                            taskRepository.taskChecked(null, it, up = true, force = false) {
+                                val pair =
+                                    NotifyUserUseCase.getNotificationAndAddStatsToUserAsText(
+                                        it.experienceDelta,
+                                        it.healthDelta,
+                                        it.goldDelta,
+                                        it.manaDelta,
+                                        it.questDamage
+                                    )
+                                showToast(pair.first)
+                            }
+                        } finally {
+                            pendingResult.finish()
                         }
                     }
                 }


### PR DESCRIPTION
Problem:
When a user completes a task directly from a notification action, the BroadcastReceiver often finishes execution and the system kills the process before the asynchronous database updates can complete. This causes a sync issue where the task is marked done on the server (user gets XP/Drops), but remains unchecked in the local task list until a full refresh.

Solution:
This PR implements goAsync() in LocalNotificationActionReceiver. This keeps the BroadcastReceiver alive while the taskRepository.taskChecked coroutine is running, ensuring the local database update completes successfully before the receiver is destroyed.

Changes:

Wrapped the complete_task_action logic in LocalNotificationActionReceiver.kt with goAsync() and pendingResult.finish().