### PR TITLE
Fix monthly weeksOfMonth dailies triggering every day of the target week

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/views/tasks/form/TaskSchedulingControls.kt
@@ -206,6 +206,17 @@ constructor(
             val zeroBasedWeekIdx = (dayOfMonth - 1) / 7
             weeksOfMonth = mutableListOf(zeroBasedWeekIdx)
             daysOfMonth = null
+            weeklyRepeat = Days(default = false).apply {
+                when (startDateCalendar.get(Calendar.DAY_OF_WEEK)) {
+                    Calendar.MONDAY -> m = true
+                    Calendar.TUESDAY -> t = true
+                    Calendar.WEDNESDAY -> w = true
+                    Calendar.THURSDAY -> th = true
+                    Calendar.FRIDAY -> f = true
+                    Calendar.SATURDAY -> s = true
+                    Calendar.SUNDAY -> su = true
+                }
+            }
             generateSummary()
         }
 


### PR DESCRIPTION
When creating a monthly daily with "week of month" mode, the repeat field was sent with all 7 days enabled. The backend combines repeat with weeksOfMonth, so all days in that week matched instead of just the intended day. Now sets only the correct day of the week in repeat, matching what the web client already does.
